### PR TITLE
[7/8] feat: support rollout routing replay (R3) in megatron

### DIFF
--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -587,6 +587,9 @@ def topk_routing_with_score_function(
         else:
             return torch.topk(scores, k=topk, dim=1)
 
+    from miles.utils.replay_base import routing_replay_manager
+    compute_topk = routing_replay_manager.get_topk_fn(compute_topk, return_probs=True)
+
     if score_function == "softmax":
         if use_pre_softmax:
             scores = torch.softmax(logits, dim=-1, dtype=torch.float32).type_as(logits)

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -201,6 +201,9 @@ class TopKRouter(Router):
             self.global_tokens_per_expert = None
             self.ga_steps = None
 
+        from miles.utils.replay_base import routing_replay_manager
+        routing_replay_manager.register_to_module(self, "routing_replay")
+
     def _maintain_float32_expert_bias(self):
         """
         Maintain the expert bias in float32.


### PR DESCRIPTION
- Add routing_replay_manager.get_topk_fn wrapper in moe_utils.py
- Register routing_replay_manager to TopKRouter module
- Depends on miles.utils.replay_base interface being available at runtime