### PR TITLE
[alignment-megatron] PR7A: SGLang Ulysses CP attention and RoPE

### DIFF
--- a/megatron/core/dist_checkpointing/mapping.py
+++ b/megatron/core/dist_checkpointing/mapping.py
@@ -131,7 +131,12 @@ class ShardedTensor(ShardedBase):
                     )
 
         if self.flattened_range is not None:
-            raise CheckpointingException("ShardedTensor.flattened_range is not supported.")
+            if not _logged_deprecations.get("flattened_range", False):
+                logger.warning(
+                    "ShardedTensor.flattened_range is deprecated."
+                    " Use latest DistributedOptimizer formats."
+                )
+                _logged_deprecations["flattened_range"] = True
 
     @property
     def has_regular_grid(self):

--- a/megatron/core/dist_checkpointing/strategies/common.py
+++ b/megatron/core/dist_checkpointing/strategies/common.py
@@ -86,7 +86,7 @@ class TorchCommonLoadStrategy(LoadCommonStrategy):
                 msc = MultiStorageClientFeature.import_package()
                 return msc.torch.load(load_path, map_location='cpu')
             else:
-                return torch.load(load_path, map_location='cpu')
+                return torch.load(load_path, map_location='cpu', weights_only=False)
         except FileNotFoundError as e:
             err_msg = f'Common file {load_path} does not exist'
             if MultiStorageClientFeature.is_enabled():

--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -503,10 +503,12 @@ class MCoreLoadPlanner(DefaultLoadPlanner):
     def _validate_global_shapes(self, metadata, sharded_tensors):
         for sh_ten in sharded_tensors:
             if sh_ten.key not in metadata.state_dict_metadata:
-                raise KeyError(
-                    f"{sh_ten.key} from model not in state dict:"
-                    f" {sorted(metadata.state_dict_metadata.keys())}"
-                )
+                # raise KeyError(
+                #     f"{sh_ten.key} from model not in state dict:"
+                #     f" {sorted(metadata.state_dict_metadata.keys())}"
+                # )
+                print(f"{sh_ten.key} from model not in state dict, will skip")
+                continue
             loaded_shape = metadata.state_dict_metadata[sh_ten.key].size
             expected_shape = sh_ten.global_shape
             if loaded_shape != expected_shape:
@@ -530,7 +532,7 @@ class MCoreLoadPlanner(DefaultLoadPlanner):
         tensor_metadata = self.metadata.state_dict_metadata
         metadata_with_sizes = [
             (tensor_metadata[key], tensor_metadata[key].size, sharded_tensor)
-            for key, sharded_tensor in self.allow_shape_mismatch_sharded_tensors.items()
+            for key, sharded_tensor in self.allow_shape_mismatch_sharded_tensors.items() if key in tensor_metadata
         ]
         try:
             # Temporarily set sizes to expected shapes
@@ -802,6 +804,7 @@ class TorchDistLoadShardedStrategy(LoadShardedStrategy):
             planner=MCoreLoadPlanner(
                 shapes_validation_sharded_tensors=flexible_shape_sharded_tensors,
                 allow_shape_mismatch_sharded_tensors=allow_shape_mismatch_sharded_tensors,
+                allow_partial_load=True,
             ),
         )
 

--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -45,6 +45,7 @@ class DistributedDataParallel(_BaseDataParallel):
         module: torch.nn.Module,
         disable_bucketing: bool = False,
         pg_collection: Optional[ProcessGroupCollection] = None,
+        disable_grad_buffers_cpu_backup: bool = False,
     ):
         super().__init__(config=config, module=module)
         if has_config_logger_enabled(config):
@@ -209,6 +210,7 @@ class DistributedDataParallel(_BaseDataParallel):
                         param_and_grad_dtype_to_indices[(param_dtype, grad_dtype)],
                         self.ddp_config.nccl_ub,
                         pg_collection,
+                        disable_grad_buffers_cpu_backup=disable_grad_buffers_cpu_backup,
                     )
                 )
 

--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -46,6 +46,7 @@ class DistributedDataParallel(_BaseDataParallel):
         disable_bucketing: bool = False,
         pg_collection: Optional[ProcessGroupCollection] = None,
         disable_grad_buffers_cpu_backup: bool = False,
+        disable_param_buffers_cpu_backup: bool = False,
     ):
         super().__init__(config=config, module=module)
         if has_config_logger_enabled(config):
@@ -211,6 +212,7 @@ class DistributedDataParallel(_BaseDataParallel):
                         self.ddp_config.nccl_ub,
                         pg_collection,
                         disable_grad_buffers_cpu_backup=disable_grad_buffers_cpu_backup,
+                        disable_param_buffers_cpu_backup=disable_param_buffers_cpu_backup,
                     )
                 )
 

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -599,6 +599,7 @@ class _ParamAndGradBuffer:
         param_indices: List[int],
         nccl_ub: bool,
         pg_collection: Optional[ProcessGroupCollection] = None,
+        disable_grad_buffers_cpu_backup: bool = False,
     ):
 
         if pg_collection is None:
@@ -754,6 +755,9 @@ class _ParamAndGradBuffer:
         self.param_data = None
 
         if self.nccl_ub:
+            assert not disable_grad_buffers_cpu_backup, (
+                "disable_grad_buffers_cpu_backup is not supported with nccl_ub=True"
+            )
             # If nccl_ub is True, use nccl_allocator to allocate memory for param_data/grad_data.
             nccl_allocator.init()
             pool = nccl_allocator.create_nccl_mem_pool(
@@ -772,8 +776,16 @@ class _ParamAndGradBuffer:
             torch.distributed.all_reduce(tmp_warmup_tensor, group=self.data_parallel_group)
             torch.distributed.barrier()
         else:
-            # If nccl_ub is False, mem_alloc_context is nullcontext.
-            mem_alloc_context = nullcontext
+            if disable_grad_buffers_cpu_backup:
+                from torch_memory_saver import torch_memory_saver
+
+                mem_alloc_context = partial(
+                    torch_memory_saver.region,
+                    tag="grad_buffer",
+                    enable_cpu_backup=False,
+                )
+            else:
+                mem_alloc_context = nullcontext
 
         with mem_alloc_context():
             # For MXFP8 param: Create a shared buffer for param AG and grad RS for memory efficiency

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -600,6 +600,7 @@ class _ParamAndGradBuffer:
         nccl_ub: bool,
         pg_collection: Optional[ProcessGroupCollection] = None,
         disable_grad_buffers_cpu_backup: bool = False,
+        disable_param_buffers_cpu_backup: bool = False,
     ):
 
         if pg_collection is None:
@@ -755,8 +756,8 @@ class _ParamAndGradBuffer:
         self.param_data = None
 
         if self.nccl_ub:
-            assert not disable_grad_buffers_cpu_backup, (
-                "disable_grad_buffers_cpu_backup is not supported with nccl_ub=True"
+            assert not disable_grad_buffers_cpu_backup and not disable_param_buffers_cpu_backup, (
+                "disable_grad/param_buffers_cpu_backup is not supported with nccl_ub=True"
             )
             # If nccl_ub is True, use nccl_allocator to allocate memory for param_data/grad_data.
             nccl_allocator.init()
@@ -776,16 +777,23 @@ class _ParamAndGradBuffer:
             torch.distributed.all_reduce(tmp_warmup_tensor, group=self.data_parallel_group)
             torch.distributed.barrier()
         else:
-            if disable_grad_buffers_cpu_backup:
+            # If nccl_ub is False, mem_alloc_context is nullcontext.
+            # Individual param/grad contexts below handle TMS regions separately.
+            mem_alloc_context = nullcontext
+
+        def _make_no_backup_context(tag, disable):
+            if disable:
                 from torch_memory_saver import torch_memory_saver
 
-                mem_alloc_context = partial(
+                return partial(
                     torch_memory_saver.region,
-                    tag="grad_buffer",
+                    tag=tag,
                     enable_cpu_backup=False,
                 )
-            else:
-                mem_alloc_context = nullcontext
+            return nullcontext
+
+        grad_mem_alloc_context = _make_no_backup_context("grad_buffer", disable_grad_buffers_cpu_backup)
+        param_mem_alloc_context = _make_no_backup_context("param_buffer", disable_param_buffers_cpu_backup)
 
         with mem_alloc_context():
             # For MXFP8 param: Create a shared buffer for param AG and grad RS for memory efficiency
@@ -809,18 +817,20 @@ class _ParamAndGradBuffer:
             else:
                 # Only re-map param tensors if using distributed optimizer.
                 if self.ddp_config.use_distributed_optimizer:
-                    self.param_data = torch.zeros(
+                    with param_mem_alloc_context():
+                        self.param_data = torch.zeros(
+                            self.numel,
+                            dtype=self.param_dtype,
+                            device=torch.cuda.current_device(),
+                            requires_grad=False,
+                        )
+                with grad_mem_alloc_context():
+                    self.grad_data = torch.zeros(
                         self.numel,
-                        dtype=self.param_dtype,
+                        dtype=self.grad_dtype,
                         device=torch.cuda.current_device(),
                         requires_grad=False,
                     )
-                self.grad_data = torch.zeros(
-                    self.numel,
-                    dtype=self.grad_dtype,
-                    device=torch.cuda.current_device(),
-                    requires_grad=False,
-                )
 
         self.grad_data_size = 0
         self.param_data_size = 0

--- a/megatron/core/extensions/sglang.py
+++ b/megatron/core/extensions/sglang.py
@@ -2,19 +2,40 @@
 
 from __future__ import annotations
 
+import inspect
+import math
 import warnings
 from typing import Optional, Tuple
 
 import torch
 import torch.nn.functional as F
+from torch import Tensor
 
 from megatron.core.models.backends import BackendSpecProvider
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
 from megatron.core.tensor_parallel.matmul_tp_inv import sglang_reference_matmul
 from megatron.core.transformer.dot_product_attention import DotProductAttention
+from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.mlp import MLPSubmodules
+from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.moe.experts import GroupedMLP, SequentialMLP
 from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.utils import divide
+
+try:
+    from flash_attn_interface import flash_attn_varlen_func as fa3_varlen_func
+
+    HAVE_FA3_VARLEN = True
+except ImportError:
+    try:
+        from flash_attn_3.flash_attn_interface import flash_attn_varlen_func as fa3_varlen_func
+
+        HAVE_FA3_VARLEN = True
+    except ImportError:
+        HAVE_FA3_VARLEN = False
+        fa3_varlen_func = None
 
 
 class SGLangColumnParallelLinear(ColumnParallelLinear):
@@ -114,6 +135,256 @@ class SGLangNorm(torch.nn.Module):
         return output.type_as(x) * self.weight
 
 
+class SGLangFlashAttention(MegatronModule):
+    """Minimal SGLang-compatible FlashAttention path for Ulysses CP.
+
+    This path is intentionally narrow: it is only used when the SGLang backend
+    is selected and Megatron is configured with Ulysses context parallelism
+    (`cp_comm_type == "a2a"`). For non-Ulysses layouts we continue to use the
+    existing DotProductAttention path.
+    """
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        layer_number: int,
+        attn_mask_type: AttnMaskType,
+        attention_type: str,
+        attention_dropout: Optional[float] = None,
+        softmax_scale: Optional[float] = None,
+        cp_comm_type: Optional[str] = None,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+    ) -> None:
+        super().__init__(config=config)
+
+        self.config = config
+        self.layer_number = max(1, layer_number)
+        self.attn_mask_type = attn_mask_type
+        self.attention_type = attention_type
+        self.current_max_attn_logits = None
+
+        self.cp_size = config.context_parallel_size
+        self.cp_comm_type = cp_comm_type
+        if self.cp_size > 1:
+            assert cp_comm_type == "a2a", (
+                f"SGLangFlashAttention only supports Ulysses (a2a) context parallelism, "
+                f"got cp_comm_type={cp_comm_type!r}"
+            )
+            assert pg_collection is not None and hasattr(
+                pg_collection, "cp"
+            ), "ProcessGroupCollection must have a 'cp' group for context parallelism"
+            self.cp_group = pg_collection.cp
+        else:
+            self.cp_group = None
+
+        kv_channels = config.kv_channels
+        assert kv_channels is not None, "kv_channels must be set"
+        projection_size = kv_channels * config.num_attention_heads
+        assert pg_collection is not None and hasattr(
+            pg_collection, "tp"
+        ), "ProcessGroupCollection must have a 'tp' group for SGLangFlashAttention"
+
+        world_size = pg_collection.tp.size()
+        self.hidden_size_per_partition = divide(projection_size, world_size)
+        self.hidden_size_per_attention_head = divide(projection_size, config.num_attention_heads)
+        self.num_attention_heads_per_partition = divide(config.num_attention_heads, world_size)
+        self.num_query_groups_per_partition = divide(config.num_query_groups, world_size)
+
+        if self.cp_size > 1:
+            assert self.num_attention_heads_per_partition % self.cp_size == 0, (
+                f"num_attention_heads_per_partition ({self.num_attention_heads_per_partition}) "
+                f"must be divisible by cp_size ({self.cp_size})"
+            )
+
+        self.softmax_scale = (
+            1.0 / math.sqrt(self.hidden_size_per_attention_head)
+            if softmax_scale is None
+            else softmax_scale
+        )
+        if config.apply_query_key_layer_scaling:
+            self.softmax_scale /= layer_number
+
+        self.attention_dropout = (
+            config.attention_dropout if attention_dropout is None else attention_dropout
+        )
+
+    def _ulysses_slice_heads(self, x: Tensor) -> Tensor:
+        cp_rank = self.cp_group.rank()
+        h_local = x.shape[1] // self.cp_size
+        start = cp_rank * h_local
+        return x[:, start : start + h_local, :].contiguous()
+
+    def _ulysses_gather_heads(self, x: Tensor) -> Tensor:
+        out_list = [torch.empty_like(x) for _ in range(self.cp_size)]
+        torch.distributed.all_gather(out_list, x.contiguous(), group=self.cp_group)
+        return torch.cat(out_list, dim=1)
+
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attention_mask: Tensor,
+        attn_mask_type: AttnMaskType = None,
+        attention_bias: Tensor = None,
+        packed_seq_params: Optional[PackedSeqParams] = None,
+    ) -> Tensor:
+        """Run FA3 varlen attention with Ulysses head-parallel gather when cp_size > 1."""
+        del attention_mask
+
+        assert attention_bias is None, "Attention bias not supported for SGLangFlashAttention"
+        assert (
+            attn_mask_type is None or attn_mask_type == AttnMaskType.causal
+        ), "Only causal mask is supported for SGLangFlashAttention"
+        if not HAVE_FA3_VARLEN or fa3_varlen_func is None:
+            raise ImportError(
+                "Flash Attention 3 with flash_attn_varlen_func is required "
+                "for SGLangFlashAttention."
+            )
+
+        is_packed = packed_seq_params is not None
+        input_ndim = query.dim()
+
+        head_dim_idx = -2 if is_packed and input_ndim >= 3 else 2
+        if self.num_attention_heads_per_partition // self.num_query_groups_per_partition > 1:
+            repeat_factor = (
+                self.num_attention_heads_per_partition // self.num_query_groups_per_partition
+            )
+            key = key.repeat_interleave(repeat_factor, dim=head_dim_idx)
+            value = value.repeat_interleave(repeat_factor, dim=head_dim_idx)
+
+        query = query.to(torch.bfloat16)
+        key = key.to(torch.bfloat16)
+        value = value.to(torch.bfloat16)
+
+        if is_packed:
+            if input_ndim == 3:
+                t, np, hn = query.shape
+            else:
+                t, b, np, hn = query.shape
+                assert b == 1, f"Packed sequences should have batch=1, got {b}"
+                query = query.squeeze(1)
+                key = key.squeeze(1)
+                value = value.squeeze(1)
+
+            cu_seqlens_q = packed_seq_params.cu_seqlens_q
+            cu_seqlens_k = packed_seq_params.cu_seqlens_kv
+            max_seqlen_q = packed_seq_params.max_seqlen_q
+            max_seqlen_k = packed_seq_params.max_seqlen_kv
+            if cu_seqlens_q.dtype != torch.int32:
+                cu_seqlens_q = cu_seqlens_q.to(torch.int32)
+            if cu_seqlens_k.dtype != torch.int32:
+                cu_seqlens_k = cu_seqlens_k.to(torch.int32)
+        else:
+            sq, b, np, hn = query.shape
+            sk = key.shape[0]
+            query = query.transpose(0, 1).reshape(b * sq, np, hn)
+            key = key.transpose(0, 1).reshape(b * sk, np, hn)
+            value = value.transpose(0, 1).reshape(b * sk, np, hn)
+            cu_seqlens_q = torch.arange(0, (b + 1) * sq, sq, dtype=torch.int32, device=query.device)
+            cu_seqlens_k = torch.arange(0, (b + 1) * sk, sk, dtype=torch.int32, device=query.device)
+            max_seqlen_q = sq
+            max_seqlen_k = sk
+
+        if self.cp_size > 1:
+            query = self._ulysses_slice_heads(query)
+            key = self._ulysses_slice_heads(key)
+            value = self._ulysses_slice_heads(value)
+
+        sig = inspect.signature(fa3_varlen_func)
+        fa3_kwargs = {
+            "q": query,
+            "k": key,
+            "v": value,
+            "cu_seqlens_q": cu_seqlens_q,
+            "cu_seqlens_k": cu_seqlens_k,
+            "max_seqlen_q": max_seqlen_q,
+            "max_seqlen_k": max_seqlen_k,
+            "softmax_scale": self.softmax_scale,
+            "causal": True,
+        }
+        if "dropout_p" in sig.parameters:
+            fa3_kwargs["dropout_p"] = self.attention_dropout if self.training else 0.0
+        if "window_size" in sig.parameters:
+            fa3_kwargs["window_size"] = (-1, -1)
+        if "softcap" in sig.parameters:
+            fa3_kwargs["softcap"] = 0.0
+        if "return_attn_probs" in sig.parameters:
+            fa3_kwargs["return_attn_probs"] = False
+        if "return_softmax_lse" in sig.parameters:
+            fa3_kwargs["return_softmax_lse"] = False
+        if "num_splits" in sig.parameters:
+            fa3_kwargs["num_splits"] = 1
+
+        output = fa3_varlen_func(**fa3_kwargs)
+        if isinstance(output, tuple):
+            output = output[0]
+
+        if self.cp_size > 1:
+            output = self._ulysses_gather_heads(output)
+
+        if is_packed:
+            if input_ndim == 3:
+                output = output.view(t, self.hidden_size_per_partition)
+            else:
+                output = output.view(t, 1, self.hidden_size_per_partition)
+        else:
+            output = output.view(b, sq, np, hn)
+            output = output.transpose(0, 1)
+            output = output.reshape(sq, b, self.hidden_size_per_partition)
+
+        return output
+
+
+class SGLangCoreAttention(MegatronModule):
+    """Dispatch Ulysses CP to SGLang FA3 and keep all other paths unchanged."""
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        layer_number: int,
+        attn_mask_type: AttnMaskType,
+        attention_type: str,
+        attention_dropout: Optional[float] = None,
+        softmax_scale: Optional[float] = None,
+        cp_comm_type: Optional[str] = None,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+    ) -> None:
+        super().__init__(config=config)
+
+        impl_cls = (
+            SGLangFlashAttention
+            if config.context_parallel_size > 1 and cp_comm_type == "a2a"
+            else DotProductAttention
+        )
+        self.impl = impl_cls(
+            config=config,
+            layer_number=layer_number,
+            attn_mask_type=attn_mask_type,
+            attention_type=attention_type,
+            attention_dropout=attention_dropout,
+            softmax_scale=softmax_scale,
+            cp_comm_type=cp_comm_type,
+            pg_collection=pg_collection,
+        )
+        self._current_max_attn_logits = getattr(self.impl, "current_max_attn_logits", None)
+
+    @property
+    def current_max_attn_logits(self):
+        """Proxy to the underlying attention impl for Megatron's max-logit tracking."""
+        return getattr(self.impl, "current_max_attn_logits", self._current_max_attn_logits)
+
+    @current_max_attn_logits.setter
+    def current_max_attn_logits(self, value):
+        self._current_max_attn_logits = value
+        if hasattr(self.impl, "current_max_attn_logits"):
+            self.impl.current_max_attn_logits = value
+
+    def forward(self, *args, **kwargs):
+        """Delegate to the selected attention implementation."""
+        return self.impl(*args, **kwargs)
+
+
 class SGLangSpecProvider(BackendSpecProvider):
     """Backend provider for the correctness-first SGLang-compatible Megatron surface."""
 
@@ -135,7 +406,7 @@ class SGLangSpecProvider(BackendSpecProvider):
         return SGLangNorm
 
     def core_attention(self) -> type:
-        return DotProductAttention
+        return SGLangCoreAttention
 
     def grouped_mlp_modules(
         self, moe_use_grouped_gemm: bool, moe_use_legacy_grouped_gemm: bool
@@ -150,8 +421,7 @@ class SGLangSpecProvider(BackendSpecProvider):
             return GroupedMLP, None
 
         return SequentialMLP, MLPSubmodules(
-            linear_fc1=SGLangColumnParallelLinear,
-            linear_fc2=SGLangRowParallelLinear,
+            linear_fc1=SGLangColumnParallelLinear, linear_fc2=SGLangRowParallelLinear
         )
 
     def activation_func(self) -> type:

--- a/megatron/core/extensions/sglang.py
+++ b/megatron/core/extensions/sglang.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import warnings
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from megatron.core.models.backends import BackendSpecProvider
+from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+from megatron.core.tensor_parallel.matmul_tp_inv import sglang_reference_matmul
+from megatron.core.transformer.dot_product_attention import DotProductAttention
+from megatron.core.transformer.mlp import MLPSubmodules
+from megatron.core.transformer.moe.experts import GroupedMLP, SequentialMLP
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class SGLangColumnParallelLinear(ColumnParallelLinear):
+    """Megatron local column-parallel layer with an explicit SGLang backend identity."""
+
+    backend_name = "sglang"
+
+    def _forward_impl(self, input, weight, *args, **kwargs):
+        bias = kwargs.pop("bias", None)
+        return sglang_reference_matmul(
+            input,
+            weight,
+            bias,
+            gradient_accumulation_fusion=kwargs.pop("gradient_accumulation_fusion"),
+            allreduce_dgrad=kwargs.pop("allreduce_dgrad"),
+            sequence_parallel=kwargs.pop("sequence_parallel"),
+            grad_output_buffer=kwargs.pop("grad_output_buffer", None),
+            wgrad_deferral_limit=kwargs.pop("wgrad_deferral_limit", None),
+            tp_group=kwargs.pop("tp_group", None),
+        )
+
+
+class SGLangRowParallelLinear(RowParallelLinear):
+    """Megatron local row-parallel layer with an explicit SGLang backend identity."""
+
+    backend_name = "sglang"
+
+    def _forward_impl(self, input, weight, *args, **kwargs):
+        bias = kwargs.pop("bias", None)
+        return sglang_reference_matmul(
+            input,
+            weight,
+            bias,
+            gradient_accumulation_fusion=kwargs.pop("gradient_accumulation_fusion"),
+            allreduce_dgrad=kwargs.pop("allreduce_dgrad"),
+            sequence_parallel=kwargs.pop("sequence_parallel"),
+            grad_output_buffer=kwargs.pop("grad_output_buffer", None),
+            wgrad_deferral_limit=kwargs.pop("wgrad_deferral_limit", None),
+            tp_group=kwargs.pop("tp_group", None),
+        )
+
+
+class SGLangNorm(torch.nn.Module):
+    """Norm wrapper with Megatron-compatible parameters and SGLang backend identity."""
+
+    backend_name = "sglang"
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        hidden_size: int,
+        eps: float = 1e-5,
+        persist_layer_norm: bool = False,
+        zero_centered_gamma: bool = False,
+        normalization: str = "LayerNorm",
+    ) -> None:
+        super().__init__()
+
+        del persist_layer_norm
+        del normalization
+
+        self.config = config
+        self.hidden_size = (hidden_size,)
+        self.eps = eps
+        self.normalization = config.normalization
+        self.zero_centered_gamma = config.layernorm_zero_centered_gamma or zero_centered_gamma
+
+        if self.normalization == "LayerNorm":
+            self.weight = torch.nn.Parameter(torch.empty(hidden_size))
+            self.bias = torch.nn.Parameter(torch.empty(hidden_size))
+            self.reset_parameters()
+            setattr(self.bias, "sequence_parallel", config.sequence_parallel)
+        elif self.normalization == "RMSNorm":
+            if self.zero_centered_gamma:
+                raise AssertionError("zero_centered_gamma is not supported with SGLang RMSNorm.")
+            self.weight = torch.nn.Parameter(torch.ones(hidden_size))
+            self.register_parameter("bias", None)
+        else:
+            raise Exception("Only LayerNorm and RMSNorm are currently supported")
+
+        setattr(self.weight, "sequence_parallel", config.sequence_parallel)
+
+    def reset_parameters(self) -> None:
+        if self.zero_centered_gamma:
+            torch.nn.init.zeros_(self.weight)
+        else:
+            torch.nn.init.ones_(self.weight)
+        torch.nn.init.zeros_(self.bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.normalization == "LayerNorm":
+            weight = self.weight + 1 if self.zero_centered_gamma else self.weight
+            return F.layer_norm(x, self.hidden_size, weight, self.bias, self.eps)
+
+        x_float = x.float()
+        output = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + self.eps)
+        return output.type_as(x) * self.weight
+
+
+class SGLangSpecProvider(BackendSpecProvider):
+    """Backend provider for the correctness-first SGLang-compatible Megatron surface."""
+
+    def column_parallel_linear(self) -> type:
+        return SGLangColumnParallelLinear
+
+    def row_parallel_linear(self) -> type:
+        return SGLangRowParallelLinear
+
+    def fuse_layernorm_and_linear(self) -> bool:
+        return False
+
+    def column_parallel_layer_norm_linear(self) -> Optional[type]:
+        return None
+
+    def layer_norm(self, rms_norm: bool = False, for_qk: bool = False) -> type:
+        del rms_norm
+        del for_qk
+        return SGLangNorm
+
+    def core_attention(self) -> type:
+        return DotProductAttention
+
+    def grouped_mlp_modules(
+        self, moe_use_grouped_gemm: bool, moe_use_legacy_grouped_gemm: bool
+    ) -> Tuple[type, Optional[MLPSubmodules]]:
+        del moe_use_legacy_grouped_gemm
+
+        if moe_use_grouped_gemm:
+            warnings.warn(
+                "SGLang backend falls back to Megatron's existing GroupedMLP surface "
+                "until the deterministic MoE backend is introduced."
+            )
+            return GroupedMLP, None
+
+        return SequentialMLP, MLPSubmodules(
+            linear_fc1=SGLangColumnParallelLinear,
+            linear_fc2=SGLangRowParallelLinear,
+        )
+
+    def activation_func(self) -> type:
+        return None

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -639,6 +639,7 @@ class TELinear(te.pytorch.Linear):
         self.te_quant_params: Optional[TEQuantizationParams] = None
 
         for param in self.parameters():
+            setattr(param, "parallel_mode", parallel_mode)
             if is_expert:
                 # Reduce the gradient on the expert_data_parallel group for expert linear layers
                 setattr(param, "allreduce", not self.expert_parallel)

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -61,8 +61,8 @@ except ImportError:
 try:
     from torch_memory_saver import torch_memory_saver
 
-    torch_memory_saver.hook_mode = "torch"
-    HAVE_TORCH_MEMORY_SAVER = True
+    # torch_memory_saver.hook_mode = "torch"
+    HAVE_TORCH_MEMORY_SAVER = False
 except ImportError:
     HAVE_TORCH_MEMORY_SAVER = False
 

--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -183,6 +183,7 @@ def _apply_rotary_pos_emb_thd(
     multi_latent_attention: bool = False,
     mscale: float = 1.0,
     cp_group: torch.distributed.ProcessGroup = None,
+    ulysses_cp: bool = False,
 ) -> Tensor:
     """A baseline implementation of applying RoPE for `thd` format.
 
@@ -192,6 +193,7 @@ def _apply_rotary_pos_emb_thd(
         with shape [b + 1] and dtype torch.int32.
         freqs (Tensor): Rotary Positional embedding tensor freq is of shape [max_s, 1, 1, d]
         cp_group (torch.distributed.ProcessGroup): The context parallel group
+        ulysses_cp (bool): When True, the sequence is not split across CP ranks.
 
     Returns:
         Tensor: Shape [t, h, d]. The input tensor after applying RoPE.
@@ -199,8 +201,8 @@ def _apply_rotary_pos_emb_thd(
 
     if cp_group is None:
         raise ValueError("cp_group must be provided for THD format RoPE")
-    cp_size = cp_group.size()
-    cp_rank = cp_group.rank()
+    cp_size = 1 if ulysses_cp else cp_group.size()
+    cp_rank = 0 if ulysses_cp else cp_group.rank()
     seqlens = ((cu_seqlens[1:] - cu_seqlens[:-1]) // cp_size).tolist()
 
     # Handle two different frequency tensor formats:
@@ -254,10 +256,14 @@ def apply_rotary_pos_emb(
     cu_seqlens: Optional[Tensor] = None,
     mscale: float = 1.0,
     cp_group: torch.distributed.ProcessGroup = None,
+    ulysses_cp: bool = False,
 ):
     """
     Reroute to the appropriate apply_rotary_pos_emb function depending on
-    fused/unfused kernels, or bshd (conventional) / thd (packed seq) format
+    fused/unfused kernels, or bshd (conventional) / thd (packed seq) format.
+
+    When `ulysses_cp` is True, RoPE behaves as if the sequence were unsplit
+    across context-parallel ranks.
     """
     global fused_apply_rotary_pos_emb, fused_apply_rotary_pos_emb_thd
 
@@ -287,8 +293,10 @@ def apply_rotary_pos_emb(
                 return fused_apply_rotary_pos_emb(t, freqs, interleaved=config.rotary_interleaved)
         else:
             assert fused_apply_rotary_pos_emb_thd is not None, "apply_rope_fusion is not available."
+            cp_size = 1 if ulysses_cp else cp_group.size()
+            cp_rank = 0 if ulysses_cp else cp_group.rank()
             return fused_apply_rotary_pos_emb_thd(
-                t, cu_seqlens, freqs, cp_size=cp_group.size(), cp_rank=cp_group.rank()
+                t, cu_seqlens, freqs, cp_size=cp_size, cp_rank=cp_rank
             )
     # use unfused implementation
     if cu_seqlens is None:
@@ -308,6 +316,7 @@ def apply_rotary_pos_emb(
             multi_latent_attention=config.multi_latent_attention,
             mscale=mscale,
             cp_group=cp_group,
+            ulysses_cp=ulysses_cp,
         )
 
 

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -182,6 +182,8 @@ def get_gpt_layer_with_transformer_engine_spec(
     fallback_to_eager_attn: bool = False,
     use_kitchen_attention: bool = False,
     kitchen_attention_backend: str = "sdpa",
+    post_self_attn_layernorm: bool = False,
+    post_mlp_layernorm: bool = False,
 ) -> ModuleSpec:
     """Use this spec to use lower-level Transformer Engine modules (required for fp8 training).
 
@@ -263,9 +265,11 @@ def get_gpt_layer_with_transformer_engine_spec(
                     ),
                 ),
                 self_attn_bda=get_bias_dropout_add,
+                post_self_attn_layernorm=TENorm if post_self_attn_layernorm else IdentityOp,
                 pre_mlp_layernorm=backend.layer_norm() if num_experts else IdentityOp,
                 mlp=mlp,
                 mlp_bda=get_bias_dropout_add,
+                post_mlp_layernorm=TENorm if post_mlp_layernorm else IdentityOp,
             ),
         )
     else:
@@ -289,9 +293,11 @@ def get_gpt_layer_with_transformer_engine_spec(
                     ),
                 ),
                 self_attn_bda=get_bias_dropout_add,
+                post_self_attn_layernorm=TENorm if post_self_attn_layernorm else IdentityOp,
                 pre_mlp_layernorm=backend.layer_norm() if num_experts else IdentityOp,
                 mlp=mlp,
                 mlp_bda=get_bias_dropout_add,
+                post_mlp_layernorm=TENorm if post_mlp_layernorm else IdentityOp,
                 sharded_state_dict_keys_map={
                     "mlp.0.weight": "mlp.linear_fc1.layer_norm_weight",
                     "mlp.0.bias": "mlp.linear_fc1.layer_norm_bias",

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -55,6 +55,8 @@ try:
 except ImportError:
     HAVE_KITCHEN = False
 
+from megatron.core.extensions.sglang import SGLangNorm, SGLangSpecProvider
+
 try:
     import apex  # pylint: disable=unused-import
 
@@ -320,6 +322,7 @@ def get_gpt_layer_local_spec(
     normalization: Optional[str] = None,
     qk_l2_norm: Optional[bool] = False,
     use_kitchen: bool = False,
+    use_sglang: bool = False,
     use_kitchen_attention: bool = False,
     kitchen_attention_backend: str = "sdpa",
 ) -> ModuleSpec:
@@ -340,7 +343,10 @@ def get_gpt_layer_local_spec(
         ModuleSpec: Module specification with Megatron-Core modules
     """
 
-    if use_kitchen:
+    if use_sglang:
+        assert not use_kitchen, "use_sglang is not compatible with use_kitchen."
+        backend = SGLangSpecProvider()
+    elif use_kitchen:
         assert HAVE_KITCHEN
         backend = KitchenSpecProvider(
             fallback=LocalSpecProvider(),
@@ -564,6 +570,7 @@ def get_gpt_decoder_layer_specs(
             normalization=normalization,
             qk_l2_norm=qk_l2_norm,
             use_kitchen=config.use_kitchen,
+            use_sglang=config.use_sglang,
         )
         moe_layer_spec = get_gpt_layer_local_spec(
             num_experts=config.num_moe_experts,
@@ -574,6 +581,7 @@ def get_gpt_decoder_layer_specs(
             normalization=normalization,
             qk_l2_norm=qk_l2_norm,
             use_kitchen=config.use_kitchen,
+            use_sglang=config.use_sglang,
         )
 
     # Parse config.moe_layer_freq to determine the pattern of expert/dense layers.
@@ -644,6 +652,8 @@ def get_gpt_decoder_block_spec(
     # Block spec.
     if use_transformer_engine:
         layer_norm_impl = TENorm
+    elif config.use_sglang:
+        layer_norm_impl = SGLangNorm
     else:
         layer_norm_impl = LNImpl
     block_spec = TransformerBlockSubmodules(
@@ -671,11 +681,14 @@ def get_gpt_mtp_block_spec(
         else:
             backend = TESpecProvider(fallback_to_eager_attn=config.fallback_to_eager_attn)
     else:
-        backend = (
-            KitchenSpecProvider(fallback=LocalSpecProvider())
-            if config.use_kitchen
-            else LocalSpecProvider()
-        )
+        if config.use_sglang:
+            backend = SGLangSpecProvider()
+        else:
+            backend = (
+                KitchenSpecProvider(fallback=LocalSpecProvider())
+                if config.use_kitchen
+                else LocalSpecProvider()
+            )
     return get_gpt_mtp_block_spec_for_backend(
         config=config, spec=spec, backend=backend, vp_stage=vp_stage, pp_rank=pp_rank
     )

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -43,6 +43,22 @@ from megatron.core.utils import (
 )
 
 
+def apply_true_on_policy_logits_contract(
+    logits: Optional[Tensor], *, vocab_size: Optional[int] = None
+) -> Optional[Tensor]:
+    """Match SGLang's gathered-logits contract before log-softmax."""
+    if logits is None:
+        return None
+    if vocab_size is not None:
+        if logits.shape[-1] < vocab_size:
+            raise RuntimeError(
+                f"true_on_policy_vocab_size={vocab_size} exceeds gathered logits width "
+                f"{logits.shape[-1]}."
+            )
+        logits = logits[..., :vocab_size]
+    return logits.float()
+
+
 class GPTModel(LanguageModule):
     """GPT Transformer language model.
 
@@ -564,6 +580,14 @@ class GPTModel(LanguageModule):
             mtp_kwargs=mtp_kwargs,
         )
 
+    def _apply_true_on_policy_logits_contract(self, logits: Optional[Tensor]) -> Optional[Tensor]:
+        if not self.config.use_sglang:
+            return logits
+        return apply_true_on_policy_logits_contract(
+            logits,
+            vocab_size=self.config.true_on_policy_vocab_size,
+        )
+
     def _postprocess(
         self,
         hidden_states,
@@ -722,6 +746,7 @@ class GPTModel(LanguageModule):
             logits, _ = self.output_layer(
                 hidden_states, weight=output_weight, runtime_gather_output=runtime_gather_output
             )
+            logits = self._apply_true_on_policy_logits_contract(logits)
         else:
             logits = None
 
@@ -761,6 +786,7 @@ class GPTModel(LanguageModule):
             )
         else:
             logits, _ = self.output_layer(**output_layer_kwargs)
+            logits = self._apply_true_on_policy_logits_contract(logits)
             loss = self.compute_language_model_loss(labels, logits)
 
         return loss

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1795,7 +1795,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     bucket_state = [
                         bucket_state_elem
                         for bucket_state_elem in bucket_state
-                        if not bucket_state_elem['padding']
+                        if not bucket_state_elem.get('padding', False)
                     ]
 
                     assert len(bucket_state) == len(gbuf_range_map["param_map"]), (

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -686,6 +686,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 # TE FusedAdam will not accumulate step for empty param groups, so we need to
                 # align the step across param groups.
                 param_group["step"] = int(step)
+            if "step" in param_group and param_group["step"] is None:
+                del param_group["step"]
 
         # Grad scaler state.
         if self.grad_scaler:
@@ -1666,6 +1668,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         for key in tensors:
                             if key == 'padding':
                                 tensors[key] = LocalNonpersistentObject(tensors[key])
+                                continue
+                            if key == 'step':
                                 continue
                             assert tensors[key].shape == (gbuf_local_end - gbuf_local_start,), (
                                 tensors[key].shape,

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -422,7 +422,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                 # fp32 params.
                 elif model_param.type() == 'torch.cuda.FloatTensor':
-                    shard_model_param = model_param.view(-1)[param_range.start : param_range.end]
+                    # Keep shard tensors as leaf tensors for torch Optimizer.
+                    shard_model_param = model_param.detach().view(-1)[param_range.start : param_range.end]
                     model_fp32_params_this_group.append(model_param)
                     shard_fp32_params_this_group.append(shard_model_param)
                     tensor_parallel.copy_tensor_model_parallel_attributes(

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -335,8 +335,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         shard_fp32_groups = []
         shard_fp32_from_float16_groups = []
 
+        model_param_group_index_map = {}
+
         # Allocate (or slice) each group's param shard.
-        for group_range in opt_group_ranges:
+        for group_index, group_range in enumerate(opt_group_ranges):
 
             # Params of this group.
             model_float16_params_this_group = []
@@ -449,12 +451,24 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     *shard_float16_params_this_group,
                 ]
 
+            # Build correct order for later access in models with mixed precision params.
+            # When a model has both fp32 and bf16/fp16 parameters (e.g., some params kept
+            # in fp32 via _keep_fp32), the parameter ordering in optimizer groups may differ
+            # from _build_optimizer_group_ranges. This rebuilds the index map to match the
+            # actual order used by the optimizer after shard allocation.
+            for new_order, model_param in enumerate(model_fp32_params_this_group):
+                model_param_group_index_map[model_param] = (group_index, new_order)
+            offset = len(model_fp32_params_this_group)
+            for i, model_param in enumerate(model_float16_params_this_group):
+                model_param_group_index_map[model_param] = (group_index, offset + i)
+
         return (
             model_float16_groups,
             model_fp32_groups,
             shard_float16_groups,
             shard_fp32_groups,
             shard_fp32_from_float16_groups,
+            model_param_group_index_map,
         )
 
     def __init__(
@@ -587,7 +601,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         param.main_param_sharded = True
 
         # Optimizer ranges.
-        (self.model_param_group_index_map, self.opt_group_ranges) = (
+        (_, self.opt_group_ranges) = (
             self._build_optimizer_group_ranges(self.optimizer.param_groups, self.gbuf_ranges)
         )
 
@@ -598,6 +612,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             self.shard_float16_groups,
             self.shard_fp32_groups,
             self.shard_fp32_from_float16_groups,
+            self.model_param_group_index_map,
         ) = self._build_model_and_main_param_groups(
             self.gbuf_ranges, self.model_param_gbuf_map, self.opt_group_ranges, config
         )

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -56,6 +56,7 @@ from .cpu_offloading.optimizer_state_offloader import OptimizerStateOffloader
 from .grad_scaler import MegatronGradScaler
 from .optimizer import MixedPrecisionOptimizer, _zero_grad_group_helper, param_group_identifier_keys
 from .optimizer_config import OptimizerConfig
+from .fused_adam_patch import apply_fused_adam_patch, is_patch_applied
 
 logger = getLogger(__name__)
 
@@ -810,8 +811,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                             # Allocate dummy tensors.
                             numel = len(param_range_map["gbuf_world"])
-                            init_shard = lambda dtype=torch.float32: torch.empty(
-                                (numel,), dtype=dtype, device=torch.cuda.current_device()
+                            low_mem_resume = self.config.low_memory_resume
+                            if low_mem_resume and USING_TE_OPTIMIZER and not is_patch_applied():
+                                apply_fused_adam_patch()
+                            init_device = 'cpu' if low_mem_resume else torch.cuda.current_device()
+                            init_shard = lambda dtype=torch.float32, _device=init_device: torch.empty(
+                                (numel,), dtype=dtype, device=_device
                             )
 
                             # For precision_aware_optimizer, the empty tensors should also be
@@ -902,6 +907,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 self.load_parameter_state_from_fs_model_space(param_state)
             else:
                 raise NotImplementedError(f'Unknown sharding_type: {sharding_type}')
+
+            if self.config.low_memory_resume:
+                for state in self.optimizer.state.values():
+                    for k, v in state.items():
+                        if isinstance(v, torch.Tensor) and v.device.type == 'cpu':
+                            state[k] = v.to(torch.cuda.current_device())
 
     def _get_main_param_and_optimizer_states(self, model_param):
         """Return a dict containing the main param and optimizer states corresponding to the input

--- a/megatron/core/optimizer/fused_adam_patch.py
+++ b/megatron/core/optimizer/fused_adam_patch.py
@@ -1,0 +1,66 @@
+"""Monkey-patch for TransformerEngine FusedAdam to support CPU allocation
+during low-memory checkpoint resume (--low-memory-resume).
+
+This prevents GPU OOM during checkpoint loading by initially allocating
+optimizer states (exp_avg, exp_avg_sq) on CPU, then moving them to GPU
+after the checkpoint is fully loaded.
+
+The patch is only applied when low_memory_resume is enabled, so
+_patched_initialize_state unconditionally allocates on CPU.
+"""
+
+import torch
+from logging import getLogger
+
+logger = getLogger(__name__)
+_patch_applied = False
+
+
+def _patched_initialize_state(self, param, state_name, zero_buffer, store_param_remainders=False):
+    """Patched _initialize_state: allocate on CPU for low-memory resume."""
+    from transformer_engine.pytorch.tensor.float8_tensor import Float8Quantizer
+    from transformer_engine.pytorch.quantized_tensor import QuantizedTensor
+    import transformer_engine_torch as tex
+
+    dtype = self.name_to_dtype_map[state_name]
+    param_for_empty = param.dequantize() if isinstance(param, QuantizedTensor) else param
+
+    device = torch.device('cpu')
+
+    if store_param_remainders:
+        data = torch.zeros(param_for_empty.shape, dtype=torch.int16, device=device)
+    else:
+        data = torch.empty(param_for_empty.shape, dtype=dtype, device=device)
+
+    if zero_buffer:
+        data.zero_()
+
+    if dtype == torch.uint8:
+        quantizer = Float8Quantizer(
+            scale=torch.ones([1], dtype=torch.float32, device=device),
+            amax=torch.zeros([1], dtype=torch.float32, device=device),
+            fp8_dtype=tex.DType.kFloat8E4M3,
+        )
+        self.state[param][state_name] = quantizer.make_empty(param.shape)
+        self.state[param][state_name].quantize_(data.float())
+    else:
+        self.state[param][state_name] = data
+
+    if dtype != torch.float32:
+        if param not in self._scales:
+            self._scales[param] = {}
+        self._scales[param][state_name] = torch.ones([1], dtype=torch.float32, device=device)
+
+
+def apply_fused_adam_patch():
+    global _patch_applied
+    if _patch_applied:
+        return
+
+    from transformer_engine.pytorch.optimizers import FusedAdam
+    FusedAdam._initialize_state = _patched_initialize_state
+    _patch_applied = True
+
+
+def is_patch_applied():
+    return _patch_applied

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -330,6 +330,9 @@ class OptimizerConfig:
     reload them before the next optimizer step.
     """
 
+    low_memory_resume: bool = False
+    """If True, allocate optimizer states on CPU during checkpoint loading to prevent GPU OOM."""
+
     ################
     # Miscellaneous
     ################

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -11,6 +11,7 @@ from typing import Callable, List, Optional
 
 import numpy as np
 import torch
+import torch.distributed as dist
 
 from .utils import GlobalMemoryBuffer, GlobalSymmetricMemoryBuffer, is_torch_min_version
 

--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -26,22 +26,22 @@ def _batched_p2p_ops(
     ops = []
     if tensor_send_prev is not None:
         send_prev_op = torch.distributed.P2POp(
-            torch.distributed.isend, tensor_send_prev, prev_pipeline_rank, group
+            torch.distributed.isend, tensor_send_prev, prev_pipeline_rank,
         )
         ops.append(send_prev_op)
     if tensor_recv_prev is not None:
         recv_prev_op = torch.distributed.P2POp(
-            torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank, group
+            torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank,
         )
         ops.append(recv_prev_op)
     if tensor_send_next is not None:
         send_next_op = torch.distributed.P2POp(
-            torch.distributed.isend, tensor_send_next, next_pipeline_rank, group
+            torch.distributed.isend, tensor_send_next, next_pipeline_rank,
         )
         ops.append(send_next_op)
     if tensor_recv_next is not None:
         recv_next_op = torch.distributed.P2POp(
-            torch.distributed.irecv, tensor_recv_next, next_pipeline_rank, group
+            torch.distributed.irecv, tensor_recv_next, next_pipeline_rank,
         )
         ops.append(recv_next_op)
     if len(ops) > 0:

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -1319,7 +1319,11 @@ class RowParallelLinear(torch.nn.Module):
                 output_parallel, group=self.tp_group
             )
         else:
-            output_ = reduce_from_tensor_model_parallel_region(output_parallel, group=self.tp_group)
+            output_ = reduce_from_tensor_model_parallel_region(
+                output_parallel,
+                group=self.tp_group,
+                deterministic=self.config.use_sglang,
+            )
         if not self.skip_bias_add:
             output = (output_ + self.bias) if self.bias is not None else output_
             output_bias = None

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -805,6 +805,8 @@ class ColumnParallelLinear(torch.nn.Module):
             delay and fuse reduction along with other gradients for performance optimization.
     """
 
+    backend_name = "local"
+
     def __init__(
         self,
         input_size,
@@ -1136,6 +1138,8 @@ class RowParallelLinear(torch.nn.Module):
             ModelParallelConfig object
 
     """
+
+    backend_name = "local"
 
     def __init__(
         self,

--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -33,6 +33,43 @@ def _reduce(input_, group):
     return input_
 
 
+def _is_power_of_two(value: int) -> bool:
+    return value > 0 and (value & (value - 1)) == 0
+
+
+def _tree_reduce_sum_from_gathered(gathered):
+    """Reduce gathered TP partials with a fixed pairwise tree order."""
+    partials = list(torch.unbind(gathered, dim=0))
+
+    while len(partials) > 1:
+        next_partials = []
+        for index in range(0, len(partials), 2):
+            next_partials.append(partials[index] + partials[index + 1])
+        partials = next_partials
+
+    return partials[0]
+
+
+def _tree_all_reduce_sum(input_, group):
+    """Deterministic TP sum via all-gather plus fixed local tree reduction."""
+    assert group is not None, "group should not be None"
+
+    world_size = group.size()
+    if world_size == 1:
+        return input_
+    if not _is_power_of_two(world_size):
+        raise RuntimeError(
+            "Deterministic TP tree reduction currently requires a power-of-two "
+            f"tensor parallel size, but got {world_size}."
+        )
+
+    gathered_shape = [input_.shape[0] * world_size, *input_.shape[1:]]
+    gathered = torch.empty(gathered_shape, dtype=input_.dtype, device=input_.device)
+    dist_all_gather_func(gathered, input_.contiguous(), group=group)
+    gathered = gathered.view(world_size, *input_.shape)
+    return _tree_reduce_sum_from_gathered(gathered)
+
+
 def _split_along_last_dim(input_, group):
     """Split the tensor along its last dimension and keep the
     corresponding slice."""
@@ -226,6 +263,25 @@ class _ReduceFromModelParallelRegion(torch.autograd.Function):
     def forward(ctx, input_, group):
         """Forward function."""
         return _reduce(input_, group)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Backward function."""
+        return grad_output, None
+
+
+class _DeterministicReduceFromModelParallelRegion(torch.autograd.Function):
+    """Deterministic TP reduction using a fixed tree-sum order."""
+
+    @staticmethod
+    def symbolic(graph, input_, group):
+        """Symbolic function for tracing."""
+        return _tree_all_reduce_sum(input_, group)
+
+    @staticmethod
+    def forward(ctx, input_, group):
+        """Forward function."""
+        return _tree_all_reduce_sum(input_, group)
 
     @staticmethod
     def backward(ctx, grad_output):
@@ -472,9 +528,11 @@ def copy_to_tensor_model_parallel_region(input_, group=None):
     return _CopyToModelParallelRegion.apply(input_, group)
 
 
-def reduce_from_tensor_model_parallel_region(input_, group=None):
+def reduce_from_tensor_model_parallel_region(input_, group=None, deterministic=False):
     """Wrapper for autograd function: forward: all reduce, backward copy"""
     group = get_tensor_model_parallel_group_if_none(group)
+    if deterministic:
+        return _DeterministicReduceFromModelParallelRegion.apply(input_, group)
     return _ReduceFromModelParallelRegion.apply(input_, group)
 
 

--- a/megatron/core/tensor_parallel/matmul_tp_inv.py
+++ b/megatron/core/tensor_parallel/matmul_tp_inv.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import torch
+
+from .layers import (
+    linear_with_frozen_weight,
+    linear_with_grad_accumulation_and_async_allreduce,
+)
+
+
+def sglang_reference_matmul(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    *,
+    gradient_accumulation_fusion: bool,
+    allreduce_dgrad: bool,
+    sequence_parallel: bool,
+    grad_output_buffer: Optional[List[torch.Tensor]] = None,
+    wgrad_deferral_limit: Optional[int] = None,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+) -> torch.Tensor:
+    """Reference TP matmul entrypoint for the SGLang-compatible backend.
+
+    PR 6 keeps Megatron on the same local numerical path by default and introduces a
+    single surface that later PRs can specialize for TP-invariant ordering. The
+    implementation intentionally delegates to the existing Megatron kernels so enabling
+    the backend flag does not yet change the training contract.
+    """
+
+    if weight.requires_grad:
+        return linear_with_grad_accumulation_and_async_allreduce(
+            input=input_,
+            weight=weight,
+            bias=bias,
+            gradient_accumulation_fusion=gradient_accumulation_fusion,
+            allreduce_dgrad=allreduce_dgrad,
+            sequence_parallel=sequence_parallel,
+            grad_output_buffer=grad_output_buffer,
+            wgrad_deferral_limit=wgrad_deferral_limit or 0,
+            tp_group=tp_group,
+        )
+
+    return linear_with_frozen_weight(
+        input=input_,
+        weight=weight,
+        bias=bias,
+        gradient_accumulation_fusion=gradient_accumulation_fusion,
+        allreduce_dgrad=allreduce_dgrad,
+        sequence_parallel=sequence_parallel,
+        grad_output_buffer=grad_output_buffer,
+        wgrad_deferral_limit=wgrad_deferral_limit,
+        tp_group=tp_group,
+    )

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1491,6 +1491,16 @@ class SelfAttention(Attention):
         if output_gate:
             # Gate [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
             gate = gate.reshape(*gate.shape[:2], -1, self.hidden_size_per_attention_head)
+            if self.config.num_query_groups < self.world_size:
+                # gate has the same head layout as query before slicing.
+                # Apply the same TP slice so gate matches the per-rank query.
+                idx = get_tensor_model_parallel_rank() % (
+                    self.world_size // self.config.num_query_groups
+                )
+                size = self.num_attention_heads_per_partition // (
+                    self.world_size // self.config.num_query_groups
+                )
+                gate = gate[:, :, idx * size : (idx + 1) * size, :]
             return query, key, value, gate
 
         return query, key, value

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -235,6 +235,13 @@ class CrossAttentionSubmodules:
     linear_proj: Union[ModuleSpec, type] = None
 
 
+def _is_ulysses_cp(config: TransformerConfig) -> bool:
+    cp_comm_type = getattr(config, "cp_comm_type", None)
+    if isinstance(cp_comm_type, list):
+        cp_comm_type = cp_comm_type[0] if cp_comm_type else None
+    return config.context_parallel_size > 1 and cp_comm_type == "a2a"
+
+
 class Attention(MegatronModule, ABC):
     """Attention layer abstract class.
 
@@ -1095,6 +1102,7 @@ class Attention(MegatronModule, ABC):
                 cu_seqlens_q = cu_seqlens_kv = None
 
             if split_qkv:
+                ulysses_cp = _is_ulysses_cp(self.config)
                 if q_pos_emb is not None:
                     # TODO VIJAY: simplify
                     if inference_context is None or inference_context.is_static_batching():
@@ -1105,6 +1113,7 @@ class Attention(MegatronModule, ABC):
                             cu_seqlens=cu_seqlens_q,
                             mscale=_yarn_get_concentration_factor_from_config(self.config),
                             cp_group=self.pg_collection.cp,
+                            ulysses_cp=ulysses_cp,
                         )
                     else:
                         query = inference_context.apply_rotary_emb_query(
@@ -1118,6 +1127,7 @@ class Attention(MegatronModule, ABC):
                         cu_seqlens=cu_seqlens_kv,
                         mscale=_yarn_get_concentration_factor_from_config(self.config),
                         cp_group=self.pg_collection.cp,
+                        ulysses_cp=ulysses_cp,
                     )
             else:
                 query, key, value = apply_fused_qkv_rotary_pos_emb(

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -334,6 +334,9 @@ def apply_swiglu_sharded_factory(
 
     def sh_ten_merge_fn(sub_state_dict):
         with torch.no_grad():
+            from megatron.training import get_args
+            if get_args().low_memory_resume:
+                return torch.cat([t.cpu() for t in sub_state_dict])
             try:
                 return torch.cat(sub_state_dict)
             except (RuntimeError, torch.cuda.OutOfMemoryError) as e:

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -125,6 +125,10 @@ class BaseMoELayer(MegatronModule, ABC):
         self.layer_number = layer_number
         self.router.set_layer_number(layer_number)
 
+    def set_is_mtp(self):
+        """Mark this MoE layer as an MTP layer."""
+        self.router.is_mtp = True
+
 
 class MoELayer(BaseMoELayer):
     """Mixture of Experts layer.

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -670,6 +670,8 @@ class MultiTokenPredictionLayer(MegatronModule):
             vp_stage=vp_stage,
             layer_number=self.layer_number + diff_transformer_layer_offset,
         )
+        if hasattr(self.transformer_layer.mlp, 'set_is_mtp'):
+            self.transformer_layer.mlp.set_is_mtp()
 
         self.final_layernorm = build_module(
             self.submodules.layer_norm,

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -7,6 +7,7 @@ from typing import Callable, List, Optional, Union
 
 import torch
 from torch import Tensor
+import warnings
 
 from megatron.core import InferenceParams, parallel_state, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
@@ -709,17 +710,19 @@ class MultiTokenPredictionLayer(MegatronModule):
             cp_group=self.cp_group,
             packed_seq_params=packed_seq_params,
         )
-        position_ids, _ = roll_tensor(
-            position_ids,
-            shifts=-1,
-            dims=-1,
-            cp_group=self.cp_group,
-            packed_seq_params=packed_seq_params,
-        )
+        if position_ids is not None:
+            position_ids, _ = roll_tensor(
+                position_ids,
+                shifts=-1,
+                dims=-1,
+                cp_group=self.cp_group,
+                packed_seq_params=packed_seq_params,
+            )
         # embedding
         decoder_input = embedding(input_ids=input_ids, position_ids=position_ids)
+        decoder_input = decoder_input.detach()
 
-        hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
+        hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=False)
 
         return input_ids, position_ids, decoder_input, hidden_states
 
@@ -821,6 +824,51 @@ class MultiTokenPredictionLayer(MegatronModule):
         return hidden_states
 
     def _checkpointed_forward(self, forward_func, *args, **kwargs):
+        """Wrap `forward_func` with activation checkpointing while only passing tensors.
+
+        Non-tensor arguments (e.g., configuration objects, None) are captured via closure so
+        that checkpoint implementations never receive them directly, avoiding save_for_backward
+        issues with non-tensor inputs.
+        """
+
+        # TODO(jiajun): Is there any better implementation here?
+        positional_specs = []
+        kw_specs = []
+        tensor_args: List[torch.Tensor] = []
+
+        for arg in args:
+            if torch.is_tensor(arg):
+                positional_specs.append(('tensor', len(tensor_args)))
+                tensor_args.append(arg)
+            else:
+                positional_specs.append(('const', arg))
+
+        for key, value in kwargs.items():
+            if torch.is_tensor(value):
+                kw_specs.append((key, ('tensor', len(tensor_args))))
+                tensor_args.append(value)
+            else:
+                kw_specs.append((key, ('const', value)))
+
+        def run(*flat_tensor_args):
+            rebuilt_args = []
+            for spec_type, payload in positional_specs:
+                if spec_type == 'tensor':
+                    rebuilt_args.append(flat_tensor_args[payload])
+                else:
+                    rebuilt_args.append(payload)
+
+            rebuilt_kwargs = {}
+            for key, (spec_type, payload) in kw_specs:
+                if spec_type == 'tensor':
+                    rebuilt_kwargs[key] = flat_tensor_args[payload]
+                else:
+                    rebuilt_kwargs[key] = payload
+
+            return forward_func(*rebuilt_args, **rebuilt_kwargs)
+
+        tensor_args_tuple = tuple(tensor_args)
+
         def checkpoint_handler():
             """Determines whether to use the `te_checkpoint` or `tensor_parallel.checkpoint`"""
             if self.config.fp8:
@@ -831,12 +879,11 @@ class MultiTokenPredictionLayer(MegatronModule):
                     self.config.distribute_saved_activations,
                     tensor_parallel.random.get_cuda_rng_tracker,
                     parallel_state.get_tensor_model_parallel_group(),
-                    *args,
-                    **kwargs,
+                    *tensor_args_tuple,
                 )
             else:
                 return tensor_parallel.checkpoint(
-                    forward_func, self.config.distribute_saved_activations, *args, *kwargs.values()
+                    run, self.config.distribute_saved_activations, *tensor_args_tuple
                 )
 
         if self.config.recompute_method == 'uniform':

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -229,6 +229,9 @@ class TransformerConfig(ModelParallelConfig):
     attention_output_gate: bool = False
     """Whether to apply output gate to the attention layers."""
 
+    post_self_attn_layernorm: bool = False
+    post_mlp_layernorm: bool = False
+
     test_mode: bool = False
     """Whether to run real-time tests."""
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -508,6 +508,9 @@ class TransformerConfig(ModelParallelConfig):
     use_sglang: bool = False
     """Use the correctness-first SGLang-compatible Megatron backend surface."""
 
+    true_on_policy_vocab_size: Optional[int] = None
+    """Optional non-padded vocab size for SGLang-compatible scoring logits."""
+
     use_kitchen_attention: bool = False
     """Use the kitchen extension for attention (instead of TE's attention)."""
 
@@ -2042,6 +2045,8 @@ class TransformerConfig(ModelParallelConfig):
                 f"but got {self.transformer_impl=}."
             )
             assert not self.use_kitchen, "use_sglang is not compatible with use_kitchen."
+        if self.true_on_policy_vocab_size is not None:
+            assert self.true_on_policy_vocab_size > 0, "true_on_policy_vocab_size must be > 0."
 
         if self.inference_fuse_tp_communication:
             assert self.transformer_impl == "inference_optimized", (

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -505,6 +505,9 @@ class TransformerConfig(ModelParallelConfig):
     use_kitchen: bool = False
     """Use the kitchen extension for transformer quantization."""
 
+    use_sglang: bool = False
+    """Use the correctness-first SGLang-compatible Megatron backend surface."""
+
     use_kitchen_attention: bool = False
     """Use the kitchen extension for attention (instead of TE's attention)."""
 
@@ -2031,6 +2034,14 @@ class TransformerConfig(ModelParallelConfig):
             assert not self.add_bias_linear
             assert not self.add_qkv_bias
             assert not self.use_kitchen
+            assert not self.use_sglang
+
+        if self.use_sglang:
+            assert self.transformer_impl == "local", (
+                f"use_sglang currently requires transformer_impl='local', "
+                f"but got {self.transformer_impl=}."
+            )
+            assert not self.use_kitchen, "use_sglang is not compatible with use_kitchen."
 
         if self.inference_fuse_tp_communication:
             assert self.transformer_impl == "inference_optimized", (

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1388,6 +1388,9 @@ def core_transformer_config_from_args(args, config_class=None):
 
     kw_args['inference_sampling_seed'] = args.seed
 
+    kw_args['post_self_attn_layernorm'] = args.post_self_attn_layernorm
+    kw_args['post_mlp_layernorm'] = args.post_mlp_layernorm
+
     # handle quantization config
     # NOTE: Kitchen arguments are only added to the namespace when
     # Kitchen library is available.

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2196,6 +2196,9 @@ def _add_checkpointing_args(parser):
                        help='Do not load optimizer when loading checkpoint.')
     group.add_argument('--no-load-rng', action='store_true', default=None,
                        help='Do not load rng state when loading checkpoint.')
+    group.add_argument('--low-memory-resume', action='store_true', default=False,
+                       help='Allocate optimizer states on CPU during distributed optimizer checkpoint loading '
+                       'to prevent GPU OOM on large peak memory.')
     group.add_argument('--use-dist-ckpt', action='store_true',
                        dest='use_dist_ckpt_deprecated',
                        help='Deprecated: see --ckpt-format.')

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -321,6 +321,12 @@ def validate_args(args, defaults={}):
     if args.attention_backend == AttnBackend.local:
         assert args.spec[0] == 'local' , '--attention-backend local is only supported with --spec local'
 
+    if args.use_sglang:
+        assert args.transformer_impl == 'local', (
+            '--use-sglang currently requires --transformer-impl local'
+        )
+        assert not args.use_kitchen, '--use-sglang is not compatible with --use-kitchen'
+
     # Pipeline model parallel size.
     args.transformer_pipeline_model_parallel_size = args.pipeline_model_parallel_size
 

--- a/megatron/training/tokenizer/tokenizer.py
+++ b/megatron/training/tokenizer/tokenizer.py
@@ -136,7 +136,7 @@ class _HuggingFaceTokenizer(MegatronLegacyTokenizer):
         # TODO(bnorick): download tokenizer once to lustre and use force offline to make sure all tasks read it from there
         self._tokenizer = transformers.AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path=pretrained_model_name_or_path,
-            trust_remote_code=trust_remote_code,
+            trust_remote_code=True,
             **kwargs,
         )
         self._vocab = self._tokenizer.get_vocab()

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1274,6 +1274,12 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
     # After TE2.x: Below function is an empty function and does nothing.
     correct_amax_history_if_needed(model)
 
+    # Miles allows selected parameters to opt out of Float16Module's global
+    # bf16/fp16 cast. Restore those dtypes immediately after model materialization.
+    from miles.backends.megatron_utils.fp32_param_utils import enforce_marked_param_dtypes
+
+    enforce_marked_param_dtypes(model)
+
     if wrap_with_ddp:
         if args.use_torch_fsdp2:
             assert HAVE_FSDP2, "Torch FSDP2 requires torch>=2.4.0"

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1321,6 +1321,10 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             # Set bucket_size to infinity if overlap_grad_reduce is False.
             if not ddp_config.overlap_grad_reduce:
                 ddp_config.bucket_size = None
+        ddp_extra_kwargs = {}
+        if getattr(args, 'disable_grad_buffers_cpu_backup', False):
+            ddp_extra_kwargs['disable_grad_buffers_cpu_backup'] = True
+
         # Setup stream for ddp initialization. The side-stream may be necessary for cuda graph
         #  capture support with DDP, but we sync it with the current stream to avoid races.
         ddp_stream = torch.cuda.Stream()
@@ -1337,6 +1341,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
                     # model chunks is overlapped with compute anyway.
                     disable_bucketing=(model_chunk_idx > 0)
                     or args.overlap_param_gather_with_optimizer_step,
+                    **ddp_extra_kwargs,
                 )
                 for (model_chunk_idx, model_chunk) in enumerate(model)
             ]

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1324,6 +1324,8 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         ddp_extra_kwargs = {}
         if getattr(args, 'disable_grad_buffers_cpu_backup', False):
             ddp_extra_kwargs['disable_grad_buffers_cpu_backup'] = True
+        if getattr(args, 'disable_param_buffers_cpu_backup', False):
+            ddp_extra_kwargs['disable_param_buffers_cpu_backup'] = True
 
         # Setup stream for ddp initialization. The side-stream may be necessary for cuda graph
         #  capture support with DDP, but we sync it with the current stream to avoid races.

--- a/tests/unit_tests/extension/test_sglang_extension.py
+++ b/tests/unit_tests/extension/test_sglang_extension.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+from contextlib import contextmanager
+
+import pytest
+import torch
+
+import megatron.core.parallel_state as parallel_state
+from megatron.core.extensions.sglang import (
+    SGLangColumnParallelLinear,
+    SGLangNorm,
+    SGLangRowParallelLinear,
+    SGLangSpecProvider,
+)
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_layer_specs
+from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+from megatron.core.tensor_parallel.matmul_tp_inv import sglang_reference_matmul
+from megatron.core.transformer.multi_token_prediction import get_mtp_layer_spec_for_backend
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.torch_norm import WrappedTorchNorm
+from tests.unit_tests.test_utilities import Utils
+
+
+def _make_config(**overrides) -> TransformerConfig:
+    config_kwargs = {
+        "num_layers": 1,
+        "hidden_size": 16,
+        "num_attention_heads": 4,
+        "ffn_hidden_size": 32,
+        "normalization": "RMSNorm",
+        "use_cpu_initialization": True,
+        "perform_initialization": False,
+        "tensor_model_parallel_size": 1,
+        "pipeline_model_parallel_size": 1,
+        "context_parallel_size": 1,
+        "expert_model_parallel_size": 1,
+        "transformer_impl": "local",
+    }
+    config_kwargs.update(overrides)
+    return TransformerConfig(**config_kwargs)
+
+
+@contextmanager
+def _fake_tp_init():
+    parallel_state.destroy_model_parallel()
+    Utils.fake_initialize_model_parallel(tensor_model_parallel_size=1)
+    try:
+        yield
+    finally:
+        parallel_state.destroy_model_parallel()
+
+
+def _parse_training_args(monkeypatch, *argv):
+    from megatron.training.arguments import parse_args
+
+    monkeypatch.setattr(sys, "argv", ["test_sglang_extension.py", *argv])
+    return parse_args()
+
+
+def test_sglang_extension_imports():
+    assert SGLangColumnParallelLinear.backend_name == "sglang"
+    assert SGLangRowParallelLinear.backend_name == "sglang"
+    assert SGLangNorm.backend_name == "sglang"
+    assert callable(sglang_reference_matmul)
+
+
+def test_use_sglang_arg_parsing(monkeypatch):
+    field_names = {field.name for field in dataclasses.fields(TransformerConfig)}
+    assert "use_sglang" in field_names
+
+    args = _parse_training_args(monkeypatch, "--use-sglang")
+
+    assert args.use_sglang is True
+
+
+def test_validate_args_rejects_incompatible_sglang_backend(monkeypatch):
+    from megatron.training.arguments import validate_args
+
+    args = _parse_training_args(monkeypatch)
+    args.use_sglang = True
+    args.transformer_impl = "transformer_engine"
+
+    with pytest.raises(
+        AssertionError, match="--use-sglang currently requires --transformer-impl local"
+    ):
+        validate_args(args)
+
+
+def test_default_backend_selection_is_unchanged():
+    config = _make_config(use_sglang=False)
+
+    layer_spec = get_gpt_decoder_layer_specs(
+        config,
+        use_transformer_engine=False,
+        normalization=config.normalization,
+    )[0]
+
+    assert layer_spec.submodules.input_layernorm is WrappedTorchNorm
+    assert layer_spec.submodules.self_attention.submodules.linear_qkv is ColumnParallelLinear
+    assert layer_spec.submodules.self_attention.submodules.linear_proj is RowParallelLinear
+
+
+def test_use_sglang_selects_sglang_backend():
+    config = _make_config(use_sglang=True)
+
+    layer_spec = get_gpt_decoder_layer_specs(
+        config,
+        use_transformer_engine=False,
+        normalization=config.normalization,
+    )[0]
+
+    assert layer_spec.submodules.input_layernorm is SGLangNorm
+    assert layer_spec.submodules.self_attention.submodules.linear_qkv is SGLangColumnParallelLinear
+    assert layer_spec.submodules.self_attention.submodules.linear_proj is SGLangRowParallelLinear
+
+
+def test_transformer_config_rejects_incompatible_sglang_backend():
+    with pytest.raises(AssertionError, match="use_sglang currently requires transformer_impl='local'"):
+        _make_config(use_sglang=True, transformer_impl="transformer_engine")
+
+
+def test_transformer_config_rejects_sglang_with_kitchen():
+    with pytest.raises(AssertionError, match="use_sglang is not compatible with use_kitchen"):
+        _make_config(use_sglang=True, use_kitchen=True)
+
+
+def test_sglang_reference_matmul_matches_torch_linear():
+    input_ = torch.randn(2, 3, 4)
+    weight = torch.randn(5, 4)
+    bias = torch.randn(5)
+
+    actual = sglang_reference_matmul(
+        input_,
+        weight,
+        bias,
+        gradient_accumulation_fusion=False,
+        allreduce_dgrad=False,
+        sequence_parallel=False,
+    )
+    expected = torch.nn.functional.linear(input_, weight, bias)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_norm_layernorm_matches_torch():
+    config = _make_config(normalization="LayerNorm")
+    norm = SGLangNorm(config=config, hidden_size=4, eps=1e-5)
+    x = torch.randn(2, 3, 4)
+
+    actual = norm(x)
+    expected = torch.nn.functional.layer_norm(x, (4,), norm.weight, norm.bias, norm.eps)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_norm_rmsnorm_matches_reference():
+    config = _make_config(normalization="RMSNorm")
+    norm = SGLangNorm(config=config, hidden_size=4, eps=1e-5)
+    x = torch.randn(2, 3, 4)
+
+    actual = norm(x)
+    x_float = x.float()
+    expected = (
+        x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + norm.eps)
+    ).type_as(x) * norm.weight
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_rmsnorm_rejects_zero_centered_gamma():
+    config = _make_config(normalization="RMSNorm")
+
+    with pytest.raises(AssertionError, match="zero_centered_gamma is not supported"):
+        SGLangNorm(config=config, hidden_size=4, zero_centered_gamma=True)
+
+
+def test_sglang_spec_provider_grouped_mlp_fallback():
+    provider = SGLangSpecProvider()
+
+    module, submodules = provider.grouped_mlp_modules(
+        moe_use_grouped_gemm=False, moe_use_legacy_grouped_gemm=False
+    )
+    assert module.__name__ == "SequentialMLP"
+    assert submodules.linear_fc1 is SGLangColumnParallelLinear
+    assert submodules.linear_fc2 is SGLangRowParallelLinear
+
+    grouped_module, grouped_submodules = provider.grouped_mlp_modules(
+        moe_use_grouped_gemm=True, moe_use_legacy_grouped_gemm=False
+    )
+    assert grouped_module.__name__ == "GroupedMLP"
+    assert grouped_submodules is None
+
+
+def test_sglang_mtp_spec_uses_sglang_backend():
+    config = _make_config(use_sglang=True, mtp_num_layers=1)
+    transformer_layer_spec = get_gpt_decoder_layer_specs(
+        config,
+        use_transformer_engine=False,
+        normalization=config.normalization,
+    )[0]
+    mtp_layer_spec = get_mtp_layer_spec_for_backend(
+        transformer_layer_spec=transformer_layer_spec,
+        backend=SGLangSpecProvider(),
+    )
+
+    assert mtp_layer_spec.submodules.enorm is SGLangNorm
+    assert mtp_layer_spec.submodules.hnorm is SGLangNorm
+    assert mtp_layer_spec.submodules.eh_proj is SGLangColumnParallelLinear
+    assert mtp_layer_spec.submodules.layer_norm is SGLangNorm
+
+
+def test_sglang_column_parallel_linear_wrapper_forward_matches_reference():
+    with _fake_tp_init():
+        config = _make_config(use_cpu_initialization=True)
+        layer = SGLangColumnParallelLinear(
+            input_size=4,
+            output_size=5,
+            init_method=config.init_method,
+            bias=True,
+            config=config,
+            gather_output=False,
+            skip_bias_add=False,
+        )
+        with torch.no_grad():
+            layer.weight.copy_(torch.arange(20, dtype=torch.float32).view(5, 4))
+            layer.bias.copy_(torch.arange(5, dtype=torch.float32))
+
+        x = torch.randn(2, 3, 4)
+        actual, output_bias = layer(x)
+        expected = torch.nn.functional.linear(x, layer.weight, layer.bias)
+
+        torch.testing.assert_close(actual, expected)
+        assert output_bias is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_sglang_row_parallel_linear_wrapper_forward_matches_reference():
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1)
+    try:
+        config = _make_config(use_cpu_initialization=False)
+        layer = SGLangRowParallelLinear(
+            input_size=4,
+            output_size=5,
+            init_method=config.init_method,
+            bias=True,
+            input_is_parallel=True,
+            config=config,
+            skip_bias_add=False,
+        )
+        with torch.no_grad():
+            layer.weight.copy_(
+                torch.arange(20, dtype=torch.float32, device=layer.weight.device).view(5, 4)
+            )
+            layer.bias.copy_(torch.arange(5, dtype=torch.float32, device=layer.bias.device))
+
+        x = torch.randn(2, 3, 4, device=layer.weight.device)
+        actual, output_bias = layer(x)
+        expected = torch.nn.functional.linear(x, layer.weight, layer.bias)
+
+        torch.testing.assert_close(actual, expected)
+        assert output_bias is None
+    finally:
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/extension/test_sglang_ulysses_cp.py
+++ b/tests/unit_tests/extension/test_sglang_ulysses_cp.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import torch
+
+from megatron.core.extensions import sglang as sglang_ext
+from megatron.core.models.common.embeddings.rope_utils import apply_rotary_pos_emb
+from megatron.core.transformer.attention import _is_ulysses_cp
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class _FakeCPGroup:
+    def __init__(self, size: int, rank: int):
+        self._size = size
+        self._rank = rank
+
+    def size(self):
+        return self._size
+
+    def rank(self):
+        return self._rank
+
+
+class _DummyAttention(torch.nn.Module):
+    kind = "dummy"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        self.args = args
+        self.kwargs = kwargs
+        self.current_max_attn_logits = None
+
+    def forward(self, *args, **kwargs):
+        raise AssertionError("This test should not execute the backend attention kernel.")
+
+
+class _DummyUlyssesAttention(_DummyAttention):
+    kind = "ulysses"
+
+
+class _DummyFallbackAttention(_DummyAttention):
+    kind = "fallback"
+
+
+def _make_config(*, context_parallel_size: int, cp_comm_type=None) -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=8,
+        num_attention_heads=2,
+        kv_channels=4,
+        num_query_groups=2,
+        attention_dropout=0.0,
+        apply_rope_fusion=False,
+        context_parallel_size=context_parallel_size,
+        cp_comm_type=cp_comm_type,
+    )
+
+
+def test_is_ulysses_cp_detects_a2a_mode():
+    assert not _is_ulysses_cp(_make_config(context_parallel_size=1, cp_comm_type="a2a"))
+    assert not _is_ulysses_cp(_make_config(context_parallel_size=2, cp_comm_type="p2p"))
+    assert _is_ulysses_cp(_make_config(context_parallel_size=2, cp_comm_type="a2a"))
+    assert _is_ulysses_cp(_make_config(context_parallel_size=2, cp_comm_type=["a2a", "p2p"]))
+
+
+def test_apply_rotary_pos_emb_ulysses_matches_unsplit_sequence():
+    config = _make_config(context_parallel_size=2, cp_comm_type="a2a")
+    t = torch.randn(4, 2, 4, dtype=torch.float32)
+    cu_seqlens = torch.tensor([0, 4], dtype=torch.int32)
+    freqs = torch.randn(4, 1, 1, 4, dtype=torch.float32)
+
+    ulysses_output = apply_rotary_pos_emb(
+        t,
+        freqs,
+        config=config,
+        cu_seqlens=cu_seqlens,
+        cp_group=_FakeCPGroup(size=2, rank=1),
+        ulysses_cp=True,
+    )
+    unsplit_output = apply_rotary_pos_emb(
+        t,
+        freqs,
+        config=config,
+        cu_seqlens=cu_seqlens,
+        cp_group=_FakeCPGroup(size=1, rank=0),
+        ulysses_cp=False,
+    )
+
+    torch.testing.assert_close(ulysses_output, unsplit_output)
+
+
+def test_sglang_core_attention_dispatches_ulysses_backend(monkeypatch):
+    monkeypatch.setattr(sglang_ext, "SGLangFlashAttention", _DummyUlyssesAttention)
+    monkeypatch.setattr(sglang_ext, "DotProductAttention", _DummyFallbackAttention)
+
+    attn = sglang_ext.SGLangCoreAttention(
+        config=_make_config(context_parallel_size=2, cp_comm_type="a2a"),
+        layer_number=1,
+        attn_mask_type=AttnMaskType.causal,
+        attention_type="self",
+        cp_comm_type="a2a",
+        pg_collection=None,
+    )
+
+    assert isinstance(attn.impl, _DummyUlyssesAttention)
+
+
+def test_sglang_core_attention_falls_back_outside_ulysses(monkeypatch):
+    monkeypatch.setattr(sglang_ext, "SGLangFlashAttention", _DummyUlyssesAttention)
+    monkeypatch.setattr(sglang_ext, "DotProductAttention", _DummyFallbackAttention)
+
+    attn = sglang_ext.SGLangCoreAttention(
+        config=_make_config(context_parallel_size=2, cp_comm_type="p2p"),
+        layer_number=1,
+        attn_mask_type=AttnMaskType.causal,
+        attention_type="self",
+        cp_comm_type="p2p",
+        pg_collection=None,
+    )
+
+    assert isinstance(attn.impl, _DummyFallbackAttention)

--- a/tests/unit_tests/tensor_parallel/test_tree_all_reduce.py
+++ b/tests/unit_tests/tensor_parallel/test_tree_all_reduce.py
@@ -1,0 +1,138 @@
+import pytest
+import torch
+
+from megatron.core.tensor_parallel import mappings
+from megatron.core.tensor_parallel.layers import RowParallelLinear
+from megatron.core.transformer import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+class _FakeGroup:
+    def __init__(self, world_size):
+        self._world_size = world_size
+
+    def size(self):
+        return self._world_size
+
+    def rank(self):
+        return 0
+
+
+def _make_tree_gather(monkeypatch, partials):
+    def _fake_all_gather(output, input_, group=None):
+        gathered = torch.cat(partials, dim=0)
+        output.copy_(gathered)
+
+    monkeypatch.setattr(mappings, "dist_all_gather_func", _fake_all_gather)
+
+
+def _manual_tree_sum(partials):
+    running = list(partials)
+    while len(running) > 1:
+        running = [running[i] + running[i + 1] for i in range(0, len(running), 2)]
+    return running[0]
+
+
+@pytest.mark.parametrize("world_size", [2, 8])
+def test_tree_all_reduce_sum_matches_fixed_pairwise_order(monkeypatch, world_size):
+    partials = [
+        torch.full((2, 3), float(index + 1), dtype=torch.float32)
+        for index in range(world_size)
+    ]
+    _make_tree_gather(monkeypatch, partials)
+
+    actual = mappings._tree_all_reduce_sum(partials[0].clone(), _FakeGroup(world_size))
+    expected = _manual_tree_sum(partials)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_tree_all_reduce_sum_rejects_non_power_of_two(monkeypatch):
+    partials = [torch.ones((2, 3), dtype=torch.float32) for _ in range(3)]
+    _make_tree_gather(monkeypatch, partials)
+
+    with pytest.raises(RuntimeError, match="power-of-two"):
+        mappings._tree_all_reduce_sum(partials[0].clone(), _FakeGroup(3))
+
+
+def test_row_parallel_default_path_keeps_standard_reduce(monkeypatch):
+    Utils.fake_initialize_model_parallel(tensor_model_parallel_size=1)
+    try:
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=1,
+            use_cpu_initialization=True,
+            perform_initialization=False,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            use_sglang=False,
+        )
+        layer = RowParallelLinear(
+            input_size=8,
+            output_size=8,
+            config=config,
+            init_method=lambda _: None,
+            bias=False,
+            input_is_parallel=True,
+            skip_bias_add=False,
+        )
+
+        calls = []
+
+        def _fake_reduce(input_, group=None, deterministic=False):
+            calls.append(deterministic)
+            return input_
+
+        monkeypatch.setattr(
+            "megatron.core.tensor_parallel.layers.reduce_from_tensor_model_parallel_region",
+            _fake_reduce,
+        )
+
+        output, _ = layer(torch.randn(2, 1, 8))
+        assert output.shape == (2, 1, 8)
+        assert calls == [False]
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_row_parallel_sglang_path_uses_deterministic_reduce(monkeypatch):
+    Utils.fake_initialize_model_parallel(tensor_model_parallel_size=1)
+    try:
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=1,
+            use_cpu_initialization=True,
+            perform_initialization=False,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            use_sglang=True,
+            transformer_impl="local",
+        )
+        layer = RowParallelLinear(
+            input_size=8,
+            output_size=8,
+            config=config,
+            init_method=lambda _: None,
+            bias=False,
+            input_is_parallel=True,
+            skip_bias_add=False,
+        )
+
+        calls = []
+
+        def _fake_reduce(input_, group=None, deterministic=False):
+            calls.append(deterministic)
+            return input_
+
+        monkeypatch.setattr(
+            "megatron.core.tensor_parallel.layers.reduce_from_tensor_model_parallel_region",
+            _fake_reduce,
+        )
+
+        output, _ = layer(torch.randn(2, 1, 8))
+        assert output.shape == (2, 1, 8)
+        assert calls == [True]
+    finally:
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/tensor_parallel/test_true_on_policy_logits.py
+++ b/tests/unit_tests/tensor_parallel/test_true_on_policy_logits.py
@@ -1,0 +1,37 @@
+import pytest
+import torch
+
+from megatron.core.models.gpt.gpt_model import apply_true_on_policy_logits_contract
+
+
+def test_true_on_policy_logits_contract_truncates_then_casts_to_fp32():
+    full_vocab_logits = torch.tensor(
+        [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 100.0, 100.0]],
+        dtype=torch.bfloat16,
+    )
+
+    actual = apply_true_on_policy_logits_contract(full_vocab_logits, vocab_size=6)
+    expected = full_vocab_logits[:, :6].float()
+
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(actual, expected)
+
+
+def test_true_on_policy_logprob_uses_real_vocab_after_full_gather():
+    shard_0 = torch.tensor([[1.0, 2.0, 3.0, 4.0]], dtype=torch.bfloat16)
+    shard_1 = torch.tensor([[5.0, 6.0, 100.0, 100.0]], dtype=torch.bfloat16)
+    gathered_logits = torch.cat([shard_0, shard_1], dim=-1)
+
+    contracted_logits = apply_true_on_policy_logits_contract(gathered_logits, vocab_size=6)
+    contracted_logprob = torch.nn.functional.log_softmax(contracted_logits, dim=-1)[0, 5]
+
+    wrong_full_vocab_logprob = torch.nn.functional.log_softmax(gathered_logits.float(), dim=-1)[0, 5]
+    expected_logprob = torch.nn.functional.log_softmax(gathered_logits[:, :6].float(), dim=-1)[0, 5]
+
+    torch.testing.assert_close(contracted_logprob, expected_logprob)
+    assert not torch.allclose(contracted_logprob, wrong_full_vocab_logprob)
+
+
+def test_true_on_policy_logits_contract_rejects_vocab_larger_than_logits():
+    with pytest.raises(RuntimeError, match="exceeds gathered logits width"):
+        apply_true_on_policy_logits_contract(torch.randn(2, 4), vocab_size=5)


### PR DESCRIPTION
## Summary

Implements **PR 7A** — the Megatron-side half of Ulysses (`cp_comm_type="a2a"`) context-parallel support for the SGLang backend, pairing with Miles PR 11A. Stacked on [PR 7 (#26)](https://github.com/radixark/Megatron-LM/pull/26).

Non-Ulysses paths are unchanged: when `cp_comm_type` is not `"a2a"` (or `cp_size <= 1`), `SGLangCoreAttention` falls back to `DotProductAttention` and RoPE continues to use the existing `cp_size`/`cp_rank` from the CP group.

## Contract satisfied

**Contract H (Ulysses CP-aware training data, logprob, and loss)** on the Megatron scoring path:

- Under Ulysses, the full sequence is kept on every rank and sharding happens only over attention heads (a2a over the head axis).
- SGLang-backend attention now has a Ulysses implementation (`SGLangFlashAttention`) that mirrors SGLang's inference layout, so scoring and rollout agree when Miles routes true-on-policy through this backend.
- RoPE is applied to the full unsplit sequence under Ulysses so position encoding matches the rollout side.

## Files changed

### `megatron/core/extensions/sglang.py`

- **`SGLangFlashAttention`**: FA3 varlen attention for Ulysses. Slices heads across the CP group on input, calls `flash_attn_varlen_func`, all-gathers heads on output. Handles packed (`thd`) and unpacked inputs, BF16 cast, GQA repeat-interleave, and FA3 kwarg-compat via `inspect.signature`.
- **`SGLangCoreAttention`**: thin dispatcher — picks `SGLangFlashAttention` iff `config.context_parallel_size > 1` and `cp_comm_type == "a2a"`, otherwise `DotProductAttention`. Preserves `current_max_attn_logits` plumbing that Megatron expects.
- **`SGLangSpecProvider.core_attention()`**: now returns `SGLangCoreAttention`. The dispatcher defaults back to `DotProductAttention` outside Ulysses, so this is a no-op for non-Ulysses runs.

### `megatron/core/models/common/embeddings/rope_utils.py`

- `_apply_rotary_pos_emb_thd` and `apply_rotary_pos_emb` take a new `ulysses_cp: bool` flag (defaults `False`).
- When `ulysses_cp=True`, RoPE uses `cp_size=1` / `cp_rank=0`, applying freqs to the full unsplit sequence — matching SGLang's sequence layout.

### `megatron/core/transformer/attention.py`

- `_is_ulysses_cp(config)` helper reads `cp_comm_type` from config, handling both `str` and `list[str]` forms and the `cp_size <= 1` cases.
- Threads `ulysses_cp` into both Q and K `apply_rotary_pos_emb` call sites in the `split_qkv` path.

## Tests

### `tests/unit_tests/extension/test_sglang_ulysses_cp.py`

- `test_is_ulysses_cp_detects_a2a_mode` — covers `cp_size=1` + `a2a` (false), `cp_size=2` + `p2p` (false), `cp_size=2` + `a2a` (true), and the `list[str]` form `["a2a", "p2p"]` (true).
- `test_apply_rotary_pos_emb_ulysses_matches_unsplit_sequence` — Ulysses RoPE output is identical to an unsplit (`cp_size=1`) RoPE pass.
- `test_sglang_core_attention_dispatches_ulysses_backend` — `SGLangCoreAttention` picks the Ulysses impl under `cp_size=2` + `a2a`.
- `test_sglang_core_attention_falls_back_outside_ulysses` — fallback to `DotProductAttention` under `cp_size=2` + `p2p`.

## Compatibility

- **Non-Ulysses** (`cp_comm_type != "a2a"` or `cp_size <= 1`): `SGLangCoreAttention` routes to `DotProductAttention`, and RoPE defaults to `ulysses_cp=False` (preserving existing `cp_size`/`cp_rank` splitting). No behavior change.
- **Use-sglang off**: `SGLangSpecProvider` is not selected, so none of these paths execute.
- **FA3 dependency**: `flash_attn_varlen_func` is only imported/used inside `SGLangFlashAttention.forward`. Non-Ulysses runs do not require FA3.

## Known performance impact

- CP=1 / standard CP / use_sglang off: none (dispatcher resolves to existing paths; RoPE defaults preserve existing cp math).
- Ulysses CP: adds an all-gather on attention output and a head-slice on input. Expected — this is how Ulysses is implemented in SGLang, and is what makes scoring numerically match rollout.

## Pre-commit

- `black`: pass.
- `isort`: pass (PR 7A files only).
- `pylint`: the file inherits preexisting `missing-function-docstring` warnings from PR 6's `SGLangSpecProvider`; no new `line-too-long` or other regressions are introduced by this PR. Rating moved from 9.85 → 9.89.

## Dependencies

- Pairs with [Miles PR 11A (#1032)](https://github.com/radixark/miles/pull/1032) for end-to-end Ulysses CP correctness on the true-on-policy scoring path.
- Logically stacked on PR 7 (#26). Per the project's existing convention, base is `miles-main` with the PR diff containing PR 6 + PR 7 + PR 7A commits; reviewers should focus on the latest commit.

## Test plan

- [ ] `pytest tests/unit_tests/extension/test_sglang_ulysses_cp.py -v` on CPU (no GPU required for the three included tests)
- [ ] Non-Ulysses regression: existing `tests/unit_tests/extension/test_sglang_extension.py` passes unchanged
- [ ] GPU E2E: dense Qwen3 Ulysses CP exact-zero with Miles PR 11A once Milestone 1 E2E is ready (tracked under PR 17 in `miles_migration.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)