### PR TITLE
[feat] Add SP and PP kernels for qwen_moe true on policy

### DIFF
--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -39,6 +39,10 @@ from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
 from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
+from miles_megatron_plugins.true_on_policy.residual_carrier import (
+    pack_sglang_pipeline_input,
+    unpack_sglang_pipeline_input,
+)
 from megatron.core.utils import (
     WrappedTensor,
     deprecate_inference_params,
@@ -343,16 +347,10 @@ class GPTModel(LanguageModule):
         Args:
             input_tensor (Tensor): Sets the input tensor for the model.
         """
-        # This is usually handled in schedules.py but some inference code still
-        # gives us non-lists or None
-        if not isinstance(input_tensor, list):
-            input_tensor = [input_tensor]
-
-        assert len(input_tensor) in (1, 2), (
-            'input_tensor should be length 1 for gpt/bert, or length 2 for the '
-            'true-on-policy residual-pair pipeline carrier'
+        hidden_states, residual = unpack_sglang_pipeline_input(
+            input_tensor, owner=type(self).__name__
         )
-        self.decoder.set_input_tensor(input_tensor[0] if len(input_tensor) == 1 else input_tensor)
+        self.decoder.set_input_tensor(pack_sglang_pipeline_input(hidden_states, residual))
 
     def _preprocess(
         self,

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -348,8 +348,11 @@ class GPTModel(LanguageModule):
         if not isinstance(input_tensor, list):
             input_tensor = [input_tensor]
 
-        assert len(input_tensor) == 1, 'input_tensor should only be length 1 for gpt/bert'
-        self.decoder.set_input_tensor(input_tensor[0])
+        assert len(input_tensor) in (1, 2), (
+            'input_tensor should be length 1 for gpt/bert, or length 2 for the '
+            'true-on-policy residual-pair pipeline carrier'
+        )
+        self.decoder.set_input_tensor(input_tensor[0] if len(input_tensor) == 1 else input_tensor)
 
     def _preprocess(
         self,

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -24,6 +24,7 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.cuda_graphs import create_cudagraphs
 from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.transformer.moe.router import MoEAuxLossAutoScaler
+from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
 from megatron.core.utils import (
     drain_embedding_wgrad_compute,
     get_attr_wrapped_model,
@@ -166,6 +167,20 @@ def deallocate_output_tensor(out, deallocate_pipeline_outputs=False):
     out.data = torch.empty((1,), device=out.device, dtype=out.dtype)
 
 
+def deallocate_output_tensors(outputs, deallocate_pipeline_outputs=False):
+    """Deallocate one or more pipeline outputs after the send has completed."""
+    if not isinstance(outputs, list):
+        outputs = [outputs]
+    if len(outputs) > 1:
+        # The true-on-policy PP carrier sends [hidden_states, residual].  Mutating
+        # both TensorImpls to scalar placeholders can corrupt backward metadata for
+        # the residual path under full activation recompute, producing NaN wgrads
+        # from an otherwise zero upstream gradient.
+        return
+    for output in outputs:
+        deallocate_output_tensor(output, deallocate_pipeline_outputs)
+
+
 def custom_backward(output, grad_output):
     '''Directly call C++ autograd engine.
 
@@ -190,6 +205,33 @@ def custom_backward(output, grad_output):
     Variable._execution_engine.run_backward(
         tensors=(output,),
         grad_tensors=(grad_output,),
+        keep_graph=False,
+        create_graph=False,
+        inputs=tuple(),
+        allow_unreachable=True,
+        accumulate_grad=True,
+    )
+
+
+def custom_backward_multiple(outputs, grad_outputs):
+    """Directly call the C++ autograd engine for multiple pipeline outputs."""
+    tensors = []
+    grad_tensors = []
+    for output, grad_output in zip(outputs, grad_outputs):
+        if not output.requires_grad:
+            continue
+        if grad_output is None:
+            assert output.numel() == 1, "implicit grad requires scalar output."
+            grad_output = torch.ones_like(output, memory_format=torch.preserve_format)
+        tensors.append(output)
+        grad_tensors.append(grad_output)
+
+    if not tensors:
+        return
+
+    Variable._execution_engine.run_backward(
+        tensors=tuple(tensors),
+        grad_tensors=tuple(grad_tensors),
         keep_graph=False,
         create_graph=False,
         inputs=tuple(),
@@ -280,11 +322,12 @@ def forward_step_calc_loss(
     # Since we use a trick to do backward on the auxiliary loss, we need to set the scale
     # explicitly.
     if hasattr(config, 'num_moe_experts') and config.num_moe_experts is not None:
+        device_tensor = output_tensor[0] if isinstance(output_tensor, list) else output_tensor
         # Calculate the loss scale based on the grad_scale_func if available, else default to 1.
         loss_scale = (
-            config.grad_scale_func(torch.ones(1, device=output_tensor.device))
+            config.grad_scale_func(torch.ones(1, device=device_tensor.device))
             if config.grad_scale_func is not None
-            else torch.ones(1, device=output_tensor.device)
+            else torch.ones(1, device=device_tensor.device)
         )
         # Set the loss scale
         if config.calculate_per_token_loss:
@@ -296,11 +339,12 @@ def forward_step_calc_loss(
 
     # Set the loss scale for Multi-Token Prediction (MTP) loss.
     if hasattr(config, 'mtp_num_layers') and config.mtp_num_layers is not None:
+        device_tensor = output_tensor[0] if isinstance(output_tensor, list) else output_tensor
         # Calculate the loss scale based on the grad_scale_func if available, else default to 1.
         loss_scale = (
-            config.grad_scale_func(torch.ones(1, device=output_tensor.device))
+            config.grad_scale_func(torch.ones(1, device=device_tensor.device))
             if config.grad_scale_func is not None
-            else torch.ones(1, device=output_tensor.device)
+            else torch.ones(1, device=device_tensor.device)
         )
         # Set the loss scale
         if config.calculate_per_token_loss:
@@ -443,6 +487,8 @@ def forward_step(
 
     if unwrap_output_tensor:
         return output_tensor, num_tokens
+    if isinstance(output_tensor, list):
+        return output_tensor, num_tokens
     return [output_tensor], num_tokens
 
 
@@ -480,16 +526,28 @@ def backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, c
     if output_tensor_grad[0] is None and config.grad_scale_func is not None:
         output_tensor[0] = config.grad_scale_func(output_tensor[0])
 
+    backward_tensors = [
+        tensor for tensor in output_tensor if tensor is not None and tensor.requires_grad
+    ]
+    backward_grads = [
+        grad
+        for tensor, grad in zip(output_tensor, output_tensor_grad)
+        if tensor is not None and tensor.requires_grad
+    ]
+
     # In multi-modal models like VLM, some batches may not have images.
     # When no image is present, the vision encoder (as a separate pipeline stage)
     # will not participate in the computation.
     # This results in a tensor that does not require gradients.
     # In such cases, we intentionally skip the backward pass while preserving zero gradients.
-    if output_tensor[0].requires_grad:
+    if backward_tensors:
         if config.deallocate_pipeline_outputs:
-            custom_backward(output_tensor[0], output_tensor_grad[0])
+            if len(backward_tensors) == 1:
+                custom_backward(backward_tensors[0], backward_grads[0])
+            else:
+                custom_backward_multiple(backward_tensors, backward_grads)
         else:
-            torch.autograd.backward(output_tensor[0], grad_tensors=output_tensor_grad[0])
+            torch.autograd.backward(backward_tensors, grad_tensors=backward_grads)
 
     # Collect the grad of the input_tensor.
     input_tensor_grad = [None]
@@ -2098,7 +2156,14 @@ def get_tensor_shapes(
     if config.sequence_parallel:
         effective_seq_length = effective_seq_length // tp_group.size()
 
-    tensor_shapes.append((effective_seq_length, micro_batch_size, config.hidden_size))
+    tensor_shape = (effective_seq_length, micro_batch_size, config.hidden_size)
+    tensor_shapes.append(tensor_shape)
+    true_on_policy_policy = resolve_true_on_policy_runtime_policy(config)
+    if (
+        true_on_policy_policy.use_sglang_residual_pair
+        and parallel_state.get_pipeline_model_parallel_world_size() > 1
+    ):
+        tensor_shapes.append(tensor_shape)
     return tensor_shapes
 
 
@@ -2310,7 +2375,7 @@ def forward_backward_pipelining_without_interleaving(
         if not forward_only:
             input_tensors.append(input_tensor)
             output_tensors.append(output_tensor)
-            deallocate_output_tensor(output_tensor[0], config.deallocate_pipeline_outputs)
+            deallocate_output_tensors(output_tensor, config.deallocate_pipeline_outputs)
 
     # Before running 1F1B, need to receive first forward tensor.
     # If all microbatches are run in warmup / cooldown phase, then no need to
@@ -2367,7 +2432,7 @@ def forward_backward_pipelining_without_interleaving(
             # Add input_tensor and output_tensor to end of list.
             input_tensors.append(input_tensor)
             output_tensors.append(output_tensor)
-            deallocate_output_tensor(output_tensor[0], config.deallocate_pipeline_outputs)
+            deallocate_output_tensors(output_tensor, config.deallocate_pipeline_outputs)
 
             # Pop input_tensor and output_tensor from the start of the list for
             # the backward pass.

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -24,7 +24,10 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.cuda_graphs import create_cudagraphs
 from megatron.core.transformer.enums import CudaGraphScope
 from megatron.core.transformer.moe.router import MoEAuxLossAutoScaler
-from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
+from miles_megatron_plugins.true_on_policy.residual_carrier import (
+    append_sglang_residual_shape_if_needed,
+    is_sglang_residual_pair_output,
+)
 from megatron.core.utils import (
     drain_embedding_wgrad_compute,
     get_attr_wrapped_model,
@@ -42,6 +45,17 @@ from .hybrid_cp_schedule import hybrid_context_parallel_forward_backward
 
 # Types
 Shape = Union[List[int], torch.Size]
+
+
+def _as_pipeline_tensor_list(tensors):
+    return tensors if isinstance(tensors, list) else [tensors]
+
+
+def _first_pipeline_tensor(tensors):
+    for tensor in _as_pipeline_tensor_list(tensors):
+        if tensor is not None:
+            return tensor
+    raise RuntimeError("Expected at least one pipeline tensor, got only None values.")
 
 
 def get_forward_backward_func(pp_size: Optional[int] = None, vp_size: Optional[int] = None):
@@ -169,15 +183,13 @@ def deallocate_output_tensor(out, deallocate_pipeline_outputs=False):
 
 def deallocate_output_tensors(outputs, deallocate_pipeline_outputs=False):
     """Deallocate one or more pipeline outputs after the send has completed."""
-    if not isinstance(outputs, list):
-        outputs = [outputs]
-    if len(outputs) > 1:
-        # The true-on-policy PP carrier sends [hidden_states, residual].  Mutating
+    if is_sglang_residual_pair_output(outputs):
+        # The true-on-policy PP carrier sends [hidden_states, residual]. Mutating
         # both TensorImpls to scalar placeholders can corrupt backward metadata for
         # the residual path under full activation recompute, producing NaN wgrads
         # from an otherwise zero upstream gradient.
         return
-    for output in outputs:
+    for output in _as_pipeline_tensor_list(outputs):
         deallocate_output_tensor(output, deallocate_pipeline_outputs)
 
 
@@ -217,7 +229,10 @@ def custom_backward_multiple(outputs, grad_outputs):
     """Directly call the C++ autograd engine for multiple pipeline outputs."""
     tensors = []
     grad_tensors = []
+    assert len(outputs) == len(grad_outputs), "outputs and grad_outputs must have the same length."
     for output, grad_output in zip(outputs, grad_outputs):
+        if output is None:
+            continue
         if not output.requires_grad:
             continue
         if grad_output is None:
@@ -322,7 +337,7 @@ def forward_step_calc_loss(
     # Since we use a trick to do backward on the auxiliary loss, we need to set the scale
     # explicitly.
     if hasattr(config, 'num_moe_experts') and config.num_moe_experts is not None:
-        device_tensor = output_tensor[0] if isinstance(output_tensor, list) else output_tensor
+        device_tensor = _first_pipeline_tensor(output_tensor)
         # Calculate the loss scale based on the grad_scale_func if available, else default to 1.
         loss_scale = (
             config.grad_scale_func(torch.ones(1, device=device_tensor.device))
@@ -339,7 +354,7 @@ def forward_step_calc_loss(
 
     # Set the loss scale for Multi-Token Prediction (MTP) loss.
     if hasattr(config, 'mtp_num_layers') and config.mtp_num_layers is not None:
-        device_tensor = output_tensor[0] if isinstance(output_tensor, list) else output_tensor
+        device_tensor = _first_pipeline_tensor(output_tensor)
         # Calculate the loss scale based on the grad_scale_func if available, else default to 1.
         loss_scale = (
             config.grad_scale_func(torch.ones(1, device=device_tensor.device))
@@ -517,10 +532,8 @@ def backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, c
         if x is not None:
             x.retain_grad()
 
-    if not isinstance(output_tensor, list):
-        output_tensor = [output_tensor]
-    if not isinstance(output_tensor_grad, list):
-        output_tensor_grad = [output_tensor_grad]
+    output_tensor = _as_pipeline_tensor_list(output_tensor)
+    output_tensor_grad = _as_pipeline_tensor_list(output_tensor_grad)
 
     # Backward pass.
     if output_tensor_grad[0] is None and config.grad_scale_func is not None:
@@ -2158,12 +2171,12 @@ def get_tensor_shapes(
 
     tensor_shape = (effective_seq_length, micro_batch_size, config.hidden_size)
     tensor_shapes.append(tensor_shape)
-    true_on_policy_policy = resolve_true_on_policy_runtime_policy(config)
-    if (
-        true_on_policy_policy.use_sglang_residual_pair
-        and parallel_state.get_pipeline_model_parallel_world_size() > 1
-    ):
-        tensor_shapes.append(tensor_shape)
+    append_sglang_residual_shape_if_needed(
+        config,
+        tensor_shapes,
+        tensor_shape,
+        pipeline_model_parallel_world_size=parallel_state.get_pipeline_model_parallel_world_size(),
+    )
     return tensor_shapes
 
 

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -30,7 +30,9 @@ from megatron.core.utils import (
 
 from ..dist_checkpointing.mapping import ShardedStateDict
 from ..transformer.utils import make_sharded_tensors_for_checkpoint
-from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
+from miles_megatron_plugins.true_on_policy.contracts import (
+    deterministic_row_parallel_reduce_enabled,
+)
 from .mappings import (
     copy_to_tensor_model_parallel_region,
     gather_from_sequence_parallel_region,
@@ -299,21 +301,21 @@ class VocabParallelEmbedding(torch.nn.Module):
         if self.tp_group.size() > 1:
             output_parallel[input_mask, :] = 0.0
 
-        true_on_policy = resolve_true_on_policy_runtime_policy(self.config)
+        deterministic_reduce = deterministic_row_parallel_reduce_enabled(self.config)
         if self.reduce_scatter_embeddings:
             # Data format change to avoid explicit tranposes : [b s h] --> [s b h].
             output_parallel = output_parallel.transpose(0, 1).contiguous()
             output = reduce_scatter_to_sequence_parallel_region(
                 output_parallel,
                 group=self.tp_group,
-                deterministic=true_on_policy.deterministic_row_parallel_reduce,
+                deterministic=deterministic_reduce,
             )
         else:
             # Reduce across all the model parallel GPUs.
             output = reduce_from_tensor_model_parallel_region(
                 output_parallel,
                 group=self.tp_group,
-                deterministic=true_on_policy.deterministic_row_parallel_reduce,
+                deterministic=deterministic_reduce,
             )
         return output
 
@@ -1446,7 +1448,7 @@ class RowParallelLinear(torch.nn.Module):
         )
 
         # All-reduce across all the partitions.
-        true_on_policy = resolve_true_on_policy_runtime_policy(self.config)
+        deterministic_reduce = deterministic_row_parallel_reduce_enabled(self.config)
         if self.explicit_expert_comm:
             assert self.skip_bias_add
             output_ = output_parallel
@@ -1454,13 +1456,13 @@ class RowParallelLinear(torch.nn.Module):
             output_ = reduce_scatter_to_sequence_parallel_region(
                 output_parallel,
                 group=self.tp_group,
-                deterministic=true_on_policy.deterministic_row_parallel_reduce,
+                deterministic=deterministic_reduce,
             )
         else:
             output_ = reduce_from_tensor_model_parallel_region(
                 output_parallel,
                 group=self.tp_group,
-                deterministic=true_on_policy.deterministic_row_parallel_reduce,
+                deterministic=deterministic_reduce,
             )
         if not self.skip_bias_add:
             output = (output_ + self.bias) if self.bias is not None else output_

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -224,6 +224,7 @@ class VocabParallelEmbedding(torch.nn.Module):
         self.embedding_dim = embedding_dim
         self.reduce_scatter_embeddings = reduce_scatter_embeddings
         self.tp_group = tp_group
+        self.config = config
 
         self.tp_group = get_tensor_model_parallel_group_if_none(self.tp_group)
 
@@ -298,15 +299,22 @@ class VocabParallelEmbedding(torch.nn.Module):
         if self.tp_group.size() > 1:
             output_parallel[input_mask, :] = 0.0
 
+        true_on_policy = resolve_true_on_policy_runtime_policy(self.config)
         if self.reduce_scatter_embeddings:
             # Data format change to avoid explicit tranposes : [b s h] --> [s b h].
             output_parallel = output_parallel.transpose(0, 1).contiguous()
             output = reduce_scatter_to_sequence_parallel_region(
-                output_parallel, group=self.tp_group
+                output_parallel,
+                group=self.tp_group,
+                deterministic=true_on_policy.deterministic_row_parallel_reduce,
             )
         else:
             # Reduce across all the model parallel GPUs.
-            output = reduce_from_tensor_model_parallel_region(output_parallel, group=self.tp_group)
+            output = reduce_from_tensor_model_parallel_region(
+                output_parallel,
+                group=self.tp_group,
+                deterministic=true_on_policy.deterministic_row_parallel_reduce,
+            )
         return output
 
     def sharded_state_dict(
@@ -1438,20 +1446,21 @@ class RowParallelLinear(torch.nn.Module):
         )
 
         # All-reduce across all the partitions.
+        true_on_policy = resolve_true_on_policy_runtime_policy(self.config)
         if self.explicit_expert_comm:
             assert self.skip_bias_add
             output_ = output_parallel
         elif self.sequence_parallel:
             output_ = reduce_scatter_to_sequence_parallel_region(
-                output_parallel, group=self.tp_group
+                output_parallel,
+                group=self.tp_group,
+                deterministic=true_on_policy.deterministic_row_parallel_reduce,
             )
         else:
             output_ = reduce_from_tensor_model_parallel_region(
                 output_parallel,
                 group=self.tp_group,
-                deterministic=resolve_true_on_policy_runtime_policy(
-                    self.config
-                ).deterministic_row_parallel_reduce,
+                deterministic=true_on_policy.deterministic_row_parallel_reduce,
             )
         if not self.skip_bias_add:
             output = (output_ + self.bias) if self.bias is not None else output_

--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -130,6 +130,18 @@ def _split_along_first_dim_with_sizes(input_, group, split_sizes):
     return torch.split(input_, split_sizes, dim=0)[rank].contiguous()
 
 
+def _deterministic_reduce_scatter_along_first_dim(
+    input_,
+    group,
+    input_split_sizes=None,
+):
+    """Apply SGLang-style fixed-order TP reduction, then split along sequence dim."""
+    reduced = _tree_all_reduce_sum(input_, group)
+    if input_split_sizes is None:
+        return _split_along_first_dim(reduced, group)
+    return _split_along_first_dim_with_sizes(reduced, group, input_split_sizes)
+
+
 def _gather_along_last_dim(input_, group):
     """Gather tensors and concatinate along the last dimension."""
 
@@ -455,10 +467,7 @@ class _DeterministicReduceScatterToSequenceParallelRegion(torch.autograd.Functio
     @staticmethod
     def symbolic(graph, input_, group, input_split_sizes=None, use_global_buffer=False):
         """Symbolic function for tracing."""
-        reduced = _tree_all_reduce_sum(input_, group)
-        if input_split_sizes is None:
-            return _split_along_first_dim(reduced, group)
-        return _split_along_first_dim_with_sizes(reduced, group, input_split_sizes)
+        return _deterministic_reduce_scatter_along_first_dim(input_, group, input_split_sizes)
 
     @staticmethod
     def forward(ctx, input_, group, input_split_sizes=None, use_global_buffer=False):
@@ -466,10 +475,7 @@ class _DeterministicReduceScatterToSequenceParallelRegion(torch.autograd.Functio
         ctx.group = group
         ctx.input_split_sizes = input_split_sizes
         ctx.use_global_buffer = use_global_buffer
-        reduced = _tree_all_reduce_sum(input_, group)
-        if input_split_sizes is None:
-            return _split_along_first_dim(reduced, group)
-        return _split_along_first_dim_with_sizes(reduced, group, input_split_sizes)
+        return _deterministic_reduce_scatter_along_first_dim(input_, group, input_split_sizes)
 
     @staticmethod
     def backward(ctx, grad_output):

--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -114,6 +114,22 @@ def _split_along_first_dim(input_, group):
     return output
 
 
+def _split_along_first_dim_with_sizes(input_, group, split_sizes):
+    """Split the tensor along its first dimension with explicit per-rank sizes."""
+    assert group is not None, "group should not be None"
+
+    world_size = group.size()
+    if world_size == 1:
+        return input_
+
+    assert split_sizes is not None
+    assert len(split_sizes) == world_size
+    assert input_.size(0) == sum(split_sizes)
+
+    rank = group.rank()
+    return torch.split(input_, split_sizes, dim=0)[rank].contiguous()
+
+
 def _gather_along_last_dim(input_, group):
     """Gather tensors and concatinate along the last dimension."""
 
@@ -433,6 +449,41 @@ class _ReduceScatterToSequenceParallelRegion(torch.autograd.Function):
         )
 
 
+class _DeterministicReduceScatterToSequenceParallelRegion(torch.autograd.Function):
+    """Deterministic TP tree reduction followed by sequence-parallel split."""
+
+    @staticmethod
+    def symbolic(graph, input_, group, input_split_sizes=None, use_global_buffer=False):
+        """Symbolic function for tracing."""
+        reduced = _tree_all_reduce_sum(input_, group)
+        if input_split_sizes is None:
+            return _split_along_first_dim(reduced, group)
+        return _split_along_first_dim_with_sizes(reduced, group, input_split_sizes)
+
+    @staticmethod
+    def forward(ctx, input_, group, input_split_sizes=None, use_global_buffer=False):
+        """Forward function."""
+        ctx.group = group
+        ctx.input_split_sizes = input_split_sizes
+        ctx.use_global_buffer = use_global_buffer
+        reduced = _tree_all_reduce_sum(input_, group)
+        if input_split_sizes is None:
+            return _split_along_first_dim(reduced, group)
+        return _split_along_first_dim_with_sizes(reduced, group, input_split_sizes)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Backward function."""
+        input_split_sizes = ctx.input_split_sizes
+        use_global_buffer = ctx.use_global_buffer
+        return (
+            _gather_along_first_dim(grad_output, ctx.group, input_split_sizes, use_global_buffer),
+            None,
+            None,
+            None,
+        )
+
+
 class _AllGatherFromTensorParallelRegion(torch.autograd.Function):
     """Gather the input from model parallel region and concatenate."""
 
@@ -569,10 +620,14 @@ def gather_from_sequence_parallel_region(
 
 
 def reduce_scatter_to_sequence_parallel_region(
-    input_, group=None, input_split_sizes=None, use_global_buffer=False
+    input_, group=None, input_split_sizes=None, use_global_buffer=False, deterministic=False
 ):
     """Wrapper for autograd function: forward: RS, backward AG <fisrt dim>"""
     group = get_tensor_model_parallel_group_if_none(group)
+    if deterministic:
+        return _DeterministicReduceScatterToSequenceParallelRegion.apply(
+            input_, group, input_split_sizes, use_global_buffer
+        )
     return _ReduceScatterToSequenceParallelRegion.apply(
         input_, group, input_split_sizes, use_global_buffer
     )

--- a/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
+++ b/megatron/core/transformer/custom_layers/batch_invariant_kernels.py
@@ -249,9 +249,17 @@ def _log_softmax_kernel(
     row_start_ptr = input_ptr + row_idx * input_row_stride
     output_row_start_ptr = output_ptr + row_idx * output_row_stride
 
-    # Step 1: Find maximum value in the row for numerical stability
-    max_val = -float("inf")
-    for col_offset in range(0, n_cols, BLOCK_SIZE):
+    # Step 1: Find maximum value in the row for numerical stability.
+    # Match SGLang's batch-invariant log_softmax exactly: infer the
+    # accumulator dtype from the input values instead of from Python literals.
+    col_idx_init = tl.arange(0, BLOCK_SIZE)
+    mask_init = col_idx_init < n_cols
+    vals_init = tl.load(
+        row_start_ptr + col_idx_init, mask=mask_init, other=-float("inf")
+    )
+    max_val = tl.max(vals_init)
+
+    for col_offset in range(BLOCK_SIZE, n_cols, BLOCK_SIZE):
         col_idx = col_offset + tl.arange(0, BLOCK_SIZE)
         mask = col_idx < n_cols
 
@@ -262,7 +270,7 @@ def _log_softmax_kernel(
         max_val = tl.max(tl.maximum(vals, max_val))
 
     # Step 2: Compute sum of exp(x - max_val)
-    sum_exp = 0.0
+    sum_exp = tl.sum(tl.zeros([1], dtype=max_val.dtype))
     for col_offset in range(0, n_cols, BLOCK_SIZE):
         col_idx = col_offset + tl.arange(0, BLOCK_SIZE)
         mask = col_idx < n_cols

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -31,6 +31,7 @@ from megatron.core.utils import internal_api
 from miles_megatron_plugins.true_on_policy.moe_layer_ext import (
     forward_compacted_true_on_policy_padding,
     run_direct_sglang_ep_forward,
+    should_compact_true_on_policy_padding,
     uses_true_on_policy_moe_kernel,
 )
 
@@ -391,8 +392,9 @@ class MoELayer(BaseMoELayer):
         """
         if self.training and self.attn_tp_group.size() > 1 and not self.config.sequence_parallel:
             raise ValueError(
-                "During training, performance may degrade if MoE and tensor parallelism"
-                "are enabled without also enabling sequence parallelism."
+                "Megatron MoE training with attention TP requires sequence parallel. "
+                "TODO: add a true-on-policy path for attention TP without sequence parallel "
+                "if that topology becomes necessary."
             )
         # Transpose from [bsz, seq_length] to [seq_length, bsz] to align with hidden_states
         if padding_mask is not None:
@@ -455,12 +457,7 @@ class MoELayer(BaseMoELayer):
 
         use_compact = (
             use_true_on_policy_moe_kernel
-            and padding_mask is not None
-            and intermediate_tensors is None
-            and padding_mask.dtype == torch.bool
-            and bool(padding_mask.any().item())
-            and not self.use_shared_expert
-            and not self.config.moe_latent_size
+            and should_compact_true_on_policy_padding(self, padding_mask, intermediate_tensors)
         )
 
         if use_compact:

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -407,14 +407,6 @@ class MoELayer(BaseMoELayer):
             shared_expert_output = None
             try:
                 if "route" in self.fwd_execution_map:
-                    if use_true_on_policy_moe_kernel:
-                        return run_direct_sglang_ep_forward(
-                            self,
-                            hidden_states,
-                            padding_mask,
-                            intermediate_tensors,
-                        )
-
                     shared_expert_output = self.shared_experts_compute(hidden_states)
                     probs, routing_map = self.route(hidden_states, padding_mask)
                     hidden_states, probs = self.preprocess(hidden_states, probs, routing_map)
@@ -455,19 +447,28 @@ class MoELayer(BaseMoELayer):
 
             return output, mlp_bias
 
-        use_compact = (
-            use_true_on_policy_moe_kernel
-            and should_compact_true_on_policy_padding(self, padding_mask, intermediate_tensors)
-        )
+        def true_on_policy_forward(hidden_states, intermediate_tensors, padding_mask=None):
+            if "route" not in self.fwd_execution_map:
+                return custom_forward(hidden_states, intermediate_tensors, padding_mask)
+            return run_direct_sglang_ep_forward(
+                self,
+                hidden_states,
+                padding_mask,
+                intermediate_tensors,
+            )
+
+        forward_impl = true_on_policy_forward if use_true_on_policy_moe_kernel else custom_forward
+
+        use_compact = should_compact_true_on_policy_padding(self, padding_mask, intermediate_tensors)
 
         if use_compact:
             outputs = forward_compacted_true_on_policy_padding(
-                hidden_states, padding_mask, custom_forward
+                hidden_states, padding_mask, forward_impl
             )
         elif self.moe_layer_recompute:
             if self.config.fp8 or self.config.fp4:
                 outputs = te_checkpoint(
-                    custom_forward,
+                    forward_impl,
                     False,
                     tensor_parallel.random.get_cuda_rng_tracker,
                     parallel_state.get_tensor_model_parallel_group(),
@@ -476,10 +477,10 @@ class MoELayer(BaseMoELayer):
                 )
             else:
                 outputs = tensor_parallel.checkpoint(
-                    custom_forward, False, hidden_states, padding_mask
+                    forward_impl, False, hidden_states, padding_mask
                 )
         else:
-            outputs = custom_forward(hidden_states, intermediate_tensors, padding_mask)
+            outputs = forward_impl(hidden_states, intermediate_tensors, padding_mask)
 
         return outputs
 

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -246,14 +246,19 @@ class SharedExpertMLP(MLP):
         """
         assert self.config.moe_shared_expert_overlap
         assert self.cached_fc2_output is not None
+        from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
+
+        true_on_policy = resolve_true_on_policy_runtime_policy(self.config)
         with torch.cuda.stream(self.stream):
             if self.config.sequence_parallel:
                 self.cached_output = reduce_scatter_to_sequence_parallel_region(
-                    self.cached_fc2_output
+                    self.cached_fc2_output,
+                    deterministic=true_on_policy.deterministic_row_parallel_reduce,
                 )
             else:
                 self.cached_output = reduce_from_tensor_model_parallel_region(
-                    self.cached_fc2_output
+                    self.cached_fc2_output,
+                    deterministic=true_on_policy.deterministic_row_parallel_reduce,
                 )
             self.cached_fc2_output = None
             set_tensor_grad_fn_sequence_sr(self.cached_output, torch.iinfo(torch.int).max)

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -25,6 +25,9 @@ from megatron.core.utils import (
     is_torch_min_version,
     make_sharded_tensor_for_checkpoint,
 )
+from miles_megatron_plugins.true_on_policy.contracts import (
+    deterministic_row_parallel_reduce_enabled,
+)
 
 
 class SharedExpertMLP(MLP):
@@ -246,19 +249,17 @@ class SharedExpertMLP(MLP):
         """
         assert self.config.moe_shared_expert_overlap
         assert self.cached_fc2_output is not None
-        from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
-
-        true_on_policy = resolve_true_on_policy_runtime_policy(self.config)
+        deterministic_reduce = deterministic_row_parallel_reduce_enabled(self.config)
         with torch.cuda.stream(self.stream):
             if self.config.sequence_parallel:
                 self.cached_output = reduce_scatter_to_sequence_parallel_region(
                     self.cached_fc2_output,
-                    deterministic=true_on_policy.deterministic_row_parallel_reduce,
+                    deterministic=deterministic_reduce,
                 )
             else:
                 self.cached_output = reduce_from_tensor_model_parallel_region(
                     self.cached_fc2_output,
-                    deterministic=true_on_policy.deterministic_row_parallel_reduce,
+                    deterministic=deterministic_reduce,
                 )
             self.cached_fc2_output = None
             set_tensor_grad_fn_sequence_sr(self.cached_output, torch.iinfo(torch.int).max)

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -49,7 +49,10 @@ logger = logging.getLogger(__name__)
      num_global_tokens: num_local_tokens*TP*EP
 """
 
-logger = logging.getLogger(__name__)
+def _deterministic_moe_combine_enabled(config: TransformerConfig) -> bool:
+    from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
+
+    return resolve_true_on_policy_runtime_policy(config).deterministic_moe_combine
 
 
 class MoETokenDispatcher:
@@ -338,7 +341,9 @@ class MoEAllGatherTokenDispatcher(MoETokenDispatcher):
         # Unpermute the tokens across ranks.
         if self.tp_size > 1 or self.ep_size > 1:
             hidden_states = reduce_scatter_to_sequence_parallel_region(
-                hidden_states.to(self.local_probs.dtype), group=self.tp_ep_group
+                hidden_states.to(self.local_probs.dtype),
+                group=self.tp_ep_group,
+                deterministic=_deterministic_moe_combine_enabled(self.config),
             ).to(hidden_states.dtype)
         return hidden_states
 
@@ -782,6 +787,7 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
                 hidden_states.to(self.probs.dtype),
                 group=self.tp_group,
                 input_split_sizes=input_split_sizes,
+                deterministic=_deterministic_moe_combine_enabled(self.config),
             ).to(hidden_states.dtype)
 
         return hidden_states

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -36,6 +36,7 @@ from megatron.core.transformer.moe.moe_utils import (
 )
 from megatron.core.transformer.moe.shared_experts import SharedExpertMLP
 from megatron.core.transformer.transformer_config import TransformerConfig
+from miles_megatron_plugins.true_on_policy.contracts import deterministic_moe_combine_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -48,11 +49,6 @@ logger = logging.getLogger(__name__)
      num_local_tokens: S/TP*B
      num_global_tokens: num_local_tokens*TP*EP
 """
-
-def _deterministic_moe_combine_enabled(config: TransformerConfig) -> bool:
-    from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
-
-    return resolve_true_on_policy_runtime_policy(config).deterministic_moe_combine
 
 
 class MoETokenDispatcher:
@@ -343,7 +339,7 @@ class MoEAllGatherTokenDispatcher(MoETokenDispatcher):
             hidden_states = reduce_scatter_to_sequence_parallel_region(
                 hidden_states.to(self.local_probs.dtype),
                 group=self.tp_ep_group,
-                deterministic=_deterministic_moe_combine_enabled(self.config),
+                deterministic=deterministic_moe_combine_enabled(self.config),
             ).to(hidden_states.dtype)
         return hidden_states
 
@@ -787,7 +783,7 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
                 hidden_states.to(self.probs.dtype),
                 group=self.tp_group,
                 input_split_sizes=input_split_sizes,
-                deterministic=_deterministic_moe_combine_enabled(self.config),
+                deterministic=deterministic_moe_combine_enabled(self.config),
             ).to(hidden_states.dtype)
 
         return hidden_states

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -31,6 +31,12 @@ from megatron.core.transformer.transformer_layer import (
 )
 from megatron.core.transformer.utils import sharded_state_dict_default
 from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
+from miles_megatron_plugins.true_on_policy.residual_carrier import (
+    attach_sglang_residual,
+    get_sglang_residual,
+    pack_sglang_pipeline_output,
+    unpack_sglang_pipeline_input,
+)
 from miles_megatron_plugins.true_on_policy.sglang_backend import SGLangFinalRMSNorm, SGLangNorm
 from megatron.core.utils import (
     WrappedTensor,
@@ -532,8 +538,8 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                 padding_mask=None,
                 sglang_residual=None,
             ):
-                if use_sglang_residual_pair and sglang_residual is not None:
-                    hidden_states._sglang_residual = sglang_residual
+                if use_sglang_residual_pair:
+                    hidden_states = attach_sglang_residual(hidden_states, sglang_residual)
 
                 for index in range(start, end):
                     layer = self._get_layer(index)
@@ -567,7 +573,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                             padding_mask=padding_mask,
                         )
                 if use_sglang_residual_pair:
-                    return hidden_states, context, getattr(hidden_states, "_sglang_residual", None)
+                    return hidden_states, context, get_sglang_residual(hidden_states)
                 return hidden_states, context
 
             return custom_forward
@@ -634,9 +640,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     *checkpoint_args,
                 )
 
-        sglang_residual = (
-            getattr(hidden_states, "_sglang_residual", None) if use_sglang_residual_pair else None
-        )
+        sglang_residual = get_sglang_residual(hidden_states) if use_sglang_residual_pair else None
         if self.config.recompute_method == 'uniform':
             # Uniformly divide the total number of Transformer layers and checkpoint
             # the input activation of each divided chunk.
@@ -694,8 +698,8 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         else:
             raise ValueError("Invalid activation recompute method.")
 
-        if use_sglang_residual_pair and sglang_residual is not None:
-            hidden_states._sglang_residual = sglang_residual
+        if use_sglang_residual_pair:
+            hidden_states = attach_sglang_residual(hidden_states, sglang_residual)
         return hidden_states
 
     def set_input_tensor(self, input_tensor: Tensor):
@@ -706,16 +710,9 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         model's forward_step_func won't have it. This function is thus
         used by internal code to bypass the input provided by the
         forward_step_func"""
-        if isinstance(input_tensor, list):
-            assert len(input_tensor) in (1, 2), (
-                "TransformerBlock input_tensor should be length 1, or length 2 for "
-                "the true-on-policy residual-pair pipeline carrier"
-            )
-            self.input_tensor = input_tensor[0]
-            self._sglang_input_residual = input_tensor[1] if len(input_tensor) == 2 else None
-        else:
-            self.input_tensor = input_tensor
-            self._sglang_input_residual = None
+        self.input_tensor, self._sglang_input_residual = unpack_sglang_pipeline_input(
+            input_tensor, owner=type(self).__name__
+        )
 
     def _should_call_local_cudagraph(self, *args, **kwargs):
         """
@@ -846,8 +843,8 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         #   is called here to be future-proof and corner-case-proof.
         hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
         true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
-        if true_on_policy_policy.use_sglang_residual_pair and sglang_input_residual is not None:
-            hidden_states._sglang_residual = sglang_input_residual
+        if true_on_policy_policy.use_sglang_residual_pair:
+            hidden_states = attach_sglang_residual(hidden_states, sglang_input_residual)
         if hasattr(self, "_sglang_input_residual"):
             del self._sglang_input_residual
 
@@ -937,7 +934,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         if self.final_layernorm is not None:
             true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
             sglang_residual = (
-                getattr(hidden_states, "_sglang_residual", None)
+                get_sglang_residual(hidden_states)
                 if true_on_policy_policy.use_sglang_residual_pair
                 else None
             )
@@ -966,14 +963,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
             hidden_states = hidden_states.clone()
 
         if not self.post_process:
-            true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
-            sglang_residual = (
-                getattr(hidden_states, "_sglang_residual", None)
-                if true_on_policy_policy.use_sglang_residual_pair
-                else None
-            )
-            if sglang_residual is not None:
-                return [hidden_states, sglang_residual]
+            return pack_sglang_pipeline_output(self.config, hidden_states)
 
         return hidden_states
 

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -706,7 +706,16 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         model's forward_step_func won't have it. This function is thus
         used by internal code to bypass the input provided by the
         forward_step_func"""
-        self.input_tensor = input_tensor
+        if isinstance(input_tensor, list):
+            assert len(input_tensor) in (1, 2), (
+                "TransformerBlock input_tensor should be length 1, or length 2 for "
+                "the true-on-policy residual-pair pipeline carrier"
+            )
+            self.input_tensor = input_tensor[0]
+            self._sglang_input_residual = input_tensor[1] if len(input_tensor) == 2 else None
+        else:
+            self.input_tensor = input_tensor
+            self._sglang_input_residual = None
 
     def _should_call_local_cudagraph(self, *args, **kwargs):
         """
@@ -816,6 +825,9 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         if not self.pre_process:
             # See set_input_tensor()
             hidden_states = self.input_tensor
+            sglang_input_residual = getattr(self, "_sglang_input_residual", None)
+        else:
+            sglang_input_residual = None
 
         # Viewless tensor.
         # - We only need to create a viewless tensor in the case of micro batch
@@ -833,6 +845,11 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         #   already creates viewless tensors. That said, make_viewless_tensor()
         #   is called here to be future-proof and corner-case-proof.
         hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
+        true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
+        if true_on_policy_policy.use_sglang_residual_pair and sglang_input_residual is not None:
+            hidden_states._sglang_residual = sglang_input_residual
+        if hasattr(self, "_sglang_input_residual"):
+            del self._sglang_input_residual
 
         if self.config.sequence_parallel:
             rng_context = tensor_parallel.get_cuda_rng_tracker().fork()
@@ -947,6 +964,16 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         # on the computational graph and will lead to unexpected errors in pipeline schedules.
         if not self.pre_process and len(self.layers) == 0 and not self.final_layernorm:
             hidden_states = hidden_states.clone()
+
+        if not self.post_process:
+            true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
+            sglang_residual = (
+                getattr(hidden_states, "_sglang_residual", None)
+                if true_on_policy_policy.use_sglang_residual_pair
+                else None
+            )
+            if sglang_residual is not None:
+                return [hidden_states, sglang_residual]
 
         return hidden_states
 

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -28,6 +28,10 @@ from miles_megatron_plugins.true_on_policy.debug import (
     register_activation_grad_debug,
     register_norm_grad_debug as _register_norm_grad_debug,
 )
+from miles_megatron_plugins.true_on_policy.residual_carrier import (
+    attach_sglang_residual,
+    get_sglang_residual,
+)
 from megatron.core.utils import (
     deprecate_inference_params,
     get_pg_rank,
@@ -599,7 +603,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # pair across layer boundaries to match SGLang's LayerCommunicator flow.
         true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
         sglang_carried_residual = (
-            getattr(hidden_states, "_sglang_residual", None)
+            get_sglang_residual(hidden_states)
             if true_on_policy_policy.use_sglang_residual_pair
             else None
         )
@@ -939,7 +943,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             inp=hidden_states, requires_grad=hidden_states.requires_grad, keep_graph=True
         )
         if true_on_policy_policy.use_sglang_residual_pair:
-            output._sglang_residual = residual
+            output = attach_sglang_residual(output, residual)
 
         return output
 

--- a/miles_megatron_plugins/true_on_policy/contracts.py
+++ b/miles_megatron_plugins/true_on_policy/contracts.py
@@ -49,6 +49,7 @@ class MegatronTrueOnPolicyRuntimePolicy:
     deterministic_moe_routing: bool
     moe_topk_tiebreak: Optional[str]
     deterministic_moe_dispatch: bool
+    deterministic_moe_combine: bool
     ep_invariant_moe: bool
 
     def requires_kernel(self, kernel_contract: KernelContract) -> bool:
@@ -78,6 +79,7 @@ DEFAULT_RUNTIME_POLICY = MegatronTrueOnPolicyRuntimePolicy(
     deterministic_moe_routing=False,
     moe_topk_tiebreak=None,
     deterministic_moe_dispatch=False,
+    deterministic_moe_combine=False,
     ep_invariant_moe=False,
 )
 
@@ -121,6 +123,7 @@ class MegatronTrueOnPolicyContract:
             deterministic_moe_routing=is_moe,
             moe_topk_tiebreak="stable_sort" if is_moe else None,
             deterministic_moe_dispatch=is_moe and uses_ep,
+            deterministic_moe_combine=is_moe,
             ep_invariant_moe=is_moe and uses_ep,
         )
 
@@ -163,3 +166,15 @@ def resolve_true_on_policy_runtime_policy(config) -> MegatronTrueOnPolicyRuntime
 
     validate_true_on_policy_contract(contract_name)
     return get_true_on_policy_contract(contract_name).policy_for(config)
+
+
+def deterministic_row_parallel_reduce_enabled(config) -> bool:
+    return resolve_true_on_policy_runtime_policy(config).deterministic_row_parallel_reduce
+
+
+def deterministic_moe_combine_enabled(config) -> bool:
+    return resolve_true_on_policy_runtime_policy(config).deterministic_moe_combine
+
+
+def sglang_residual_pair_enabled(config) -> bool:
+    return resolve_true_on_policy_runtime_policy(config).use_sglang_residual_pair

--- a/miles_megatron_plugins/true_on_policy/moe_layer_ext.py
+++ b/miles_megatron_plugins/true_on_policy/moe_layer_ext.py
@@ -46,6 +46,30 @@ def uses_true_on_policy_moe_kernel(moe_layer) -> bool:
     return policy.enabled and policy.requires_kernel(QWEN3_MOE_SGLANG_MATH)
 
 
+def _under_sp_or_attn_tp(moe_layer) -> bool:
+    return moe_layer.config.sequence_parallel or moe_layer.attn_tp_group.size() > 1
+
+
+def should_compact_true_on_policy_padding(
+    moe_layer,
+    padding_mask: Optional[torch.Tensor],
+    intermediate_tensors,
+) -> bool:
+    if padding_mask is None or intermediate_tensors is not None:
+        return False
+    if _under_sp_or_attn_tp(moe_layer):
+        # Under SP / attention-TP, compaction can make all-padding local shards
+        # skip MoE collectives while peer ranks still enter EP communication.
+        return False
+    if moe_layer.use_shared_expert or moe_layer.config.moe_latent_size:
+        return False
+    return (
+        uses_true_on_policy_moe_kernel(moe_layer)
+        and padding_mask.dtype == torch.bool
+        and bool(padding_mask.any().item())
+    )
+
+
 def forward_compacted_true_on_policy_padding(
     hidden_states: torch.Tensor,
     padding_mask: torch.Tensor,
@@ -78,7 +102,6 @@ def run_direct_sglang_ep_forward(
     assert uses_true_on_policy_moe_kernel(moe_layer)
     assert isinstance(moe_layer.experts, SGLangGroupedMLP)
     assert moe_layer.token_dispatcher.ep_size > 1
-    assert not (padding_mask is not None and bool(padding_mask.any().item()))
 
     output = _forward_sglang_ep(moe_layer, hidden_states)
     assert output is not None, "Router config not supported for true-on-policy MoE"

--- a/miles_megatron_plugins/true_on_policy/residual_carrier.py
+++ b/miles_megatron_plugins/true_on_policy/residual_carrier.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from .contracts import sglang_residual_pair_enabled
+
+
+_RESIDUAL_ATTR = "_sglang_residual"
+
+
+def get_sglang_residual(hidden_states: torch.Tensor) -> Optional[torch.Tensor]:
+    return getattr(hidden_states, _RESIDUAL_ATTR, None)
+
+
+def attach_sglang_residual(
+    hidden_states: torch.Tensor,
+    residual: Optional[torch.Tensor],
+) -> torch.Tensor:
+    if residual is None:
+        if hasattr(hidden_states, _RESIDUAL_ATTR):
+            delattr(hidden_states, _RESIDUAL_ATTR)
+    else:
+        setattr(hidden_states, _RESIDUAL_ATTR, residual)
+    return hidden_states
+
+
+def is_sglang_residual_pair_output(value) -> bool:
+    if not isinstance(value, list) or len(value) != 2:
+        return False
+    hidden_states, residual = value
+    return (
+        isinstance(hidden_states, torch.Tensor)
+        and isinstance(residual, torch.Tensor)
+        and get_sglang_residual(hidden_states) is residual
+    )
+
+
+def unpack_sglang_pipeline_input(input_tensor, *, owner: str = "TransformerBlock"):
+    if isinstance(input_tensor, list):
+        assert len(input_tensor) in (1, 2), (
+            f"{owner} input_tensor should be length 1, or length 2 for the "
+            "true-on-policy residual-pair pipeline carrier."
+        )
+        residual = input_tensor[1] if len(input_tensor) == 2 else None
+        return input_tensor[0], residual
+    return input_tensor, None
+
+
+def pack_sglang_pipeline_input(hidden_states: torch.Tensor, residual: Optional[torch.Tensor]):
+    if residual is None:
+        return hidden_states
+    return [attach_sglang_residual(hidden_states, residual), residual]
+
+
+def pack_sglang_pipeline_output(config, hidden_states: torch.Tensor):
+    if not sglang_residual_pair_enabled(config):
+        return hidden_states
+
+    residual = get_sglang_residual(hidden_states)
+    if residual is None:
+        return hidden_states
+    return [hidden_states, residual]
+
+
+def append_sglang_residual_shape_if_needed(
+    config,
+    tensor_shapes: list,
+    tensor_shape,
+    *,
+    pipeline_model_parallel_world_size: int,
+) -> None:
+    if sglang_residual_pair_enabled(config) and pipeline_model_parallel_world_size > 1:
+        tensor_shapes.append(tensor_shape)

--- a/miles_megatron_plugins/true_on_policy/schema.py
+++ b/miles_megatron_plugins/true_on_policy/schema.py
@@ -35,7 +35,7 @@ QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
     logprob_contract="sglang_prefill",
     sglang_attention_backend="fa3",
     fsdp_attention_implementation="flash_attention_3",
-    disable_megatron_sequence_parallel=True,
+    disable_megatron_sequence_parallel=False,
 )
 
 QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
@@ -45,5 +45,5 @@ QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
     logprob_contract="sglang_prefill",
     sglang_attention_backend="fa3",
     fsdp_attention_implementation="flash_attention_3",
-    disable_megatron_sequence_parallel=True,
+    disable_megatron_sequence_parallel=False,
 )

--- a/tests/unit_tests/extension/test_sglang_extension.py
+++ b/tests/unit_tests/extension/test_sglang_extension.py
@@ -33,7 +33,21 @@ from miles_megatron_plugins.true_on_policy.sglang_backend import (
     is_sglang_rope_enabled,
     resolve_true_on_policy_runtime_policy,
 )
-from miles_megatron_plugins.true_on_policy.contracts import get_true_on_policy_contract
+from miles_megatron_plugins.true_on_policy.contracts import (
+    deterministic_moe_combine_enabled,
+    deterministic_row_parallel_reduce_enabled,
+    get_true_on_policy_contract,
+    sglang_residual_pair_enabled,
+)
+from miles_megatron_plugins.true_on_policy.residual_carrier import (
+    append_sglang_residual_shape_if_needed,
+    attach_sglang_residual,
+    get_sglang_residual,
+    is_sglang_residual_pair_output,
+    pack_sglang_pipeline_input,
+    pack_sglang_pipeline_output,
+    unpack_sglang_pipeline_input,
+)
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_decoder_layer_specs,
     get_gpt_layer_local_spec,
@@ -209,6 +223,7 @@ def test_contract_object_owns_megatron_runtime_policy_values():
     assert policy.use_sglang_final_norm
     assert policy.use_sglang_residual_pair
     assert not policy.use_ulysses_cp_recompute_fallback
+    assert not policy.deterministic_moe_combine
 
 
 def test_qwen3_moe_contract_splits_tp_cp_and_ep_policy_values():
@@ -235,6 +250,60 @@ def test_qwen3_moe_contract_splits_tp_cp_and_ep_policy_values():
     assert policy.moe_topk_tiebreak == "stable_sort"
     assert policy.ep_invariant_moe
     assert policy.deterministic_moe_dispatch
+    assert policy.deterministic_moe_combine
+
+
+def test_contract_policy_helpers_expose_common_runtime_switches():
+    dense_config = _make_config(true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1)
+    moe_config = _make_config(
+        expert_model_parallel_size=2,
+        num_moe_experts=8,
+        true_on_policy_contract=QWEN3_MOE_TRUE_ON_POLICY_V1,
+    )
+    default_config = _make_config()
+
+    assert deterministic_row_parallel_reduce_enabled(dense_config)
+    assert sglang_residual_pair_enabled(dense_config)
+    assert not deterministic_moe_combine_enabled(dense_config)
+    assert deterministic_moe_combine_enabled(moe_config)
+    assert not deterministic_row_parallel_reduce_enabled(default_config)
+    assert not sglang_residual_pair_enabled(default_config)
+
+
+def test_sglang_residual_carrier_roundtrip_and_shape_policy():
+    config = _make_config(true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1)
+    hidden_states = torch.randn(2, 1, 4)
+    residual = torch.randn(2, 1, 4)
+
+    attach_sglang_residual(hidden_states, residual)
+    assert get_sglang_residual(hidden_states) is residual
+
+    output = pack_sglang_pipeline_output(config, hidden_states)
+    assert output[0] is hidden_states
+    assert output[1] is residual
+    assert is_sglang_residual_pair_output(output)
+
+    unpacked_hidden_states, unpacked_residual = unpack_sglang_pipeline_input(output)
+    assert unpacked_hidden_states is hidden_states
+    assert unpacked_residual is residual
+
+    decoder_input = pack_sglang_pipeline_input(hidden_states, residual)
+    assert decoder_input[0] is hidden_states
+    assert decoder_input[1] is residual
+    assert is_sglang_residual_pair_output(decoder_input)
+
+    tensor_shapes = [(2, 1, 4)]
+    append_sglang_residual_shape_if_needed(
+        config,
+        tensor_shapes,
+        tensor_shapes[0],
+        pipeline_model_parallel_world_size=2,
+    )
+    assert tensor_shapes == [(2, 1, 4), (2, 1, 4)]
+
+    attach_sglang_residual(hidden_states, None)
+    assert get_sglang_residual(hidden_states) is None
+    assert pack_sglang_pipeline_output(config, hidden_states) is hidden_states
 
 
 def test_true_on_policy_moe_local_spec_keeps_pre_mlp_layernorm_checkpoint_key():

--- a/tests/unit_tests/extension/test_sglang_extension.py
+++ b/tests/unit_tests/extension/test_sglang_extension.py
@@ -687,14 +687,15 @@ def test_sglang_norm_rmsnorm_accepts_residual_pair():
     residual = torch.randn(2, 3, 4, dtype=torch.bfloat16)
 
     actual, actual_residual = norm(x, residual)
-    x_float = x.float() + residual.float()
+    rounded_residual = (x.float() + residual.float()).to(x.dtype)
+    x_float = rounded_residual.float()
     expected = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + norm.eps)
     expected = norm.weight.float() * expected
 
     assert actual.dtype == torch.float32
-    assert actual_residual.dtype == torch.float32
+    assert actual_residual.dtype == torch.bfloat16
     torch.testing.assert_close(actual, expected)
-    torch.testing.assert_close(actual_residual, x_float)
+    torch.testing.assert_close(actual_residual, rounded_residual)
 
 
 def test_sglang_qk_rmsnorm_matches_source_truth_dtype_boundary():

--- a/tests/unit_tests/tensor_parallel/test_mappings.py
+++ b/tests/unit_tests/tensor_parallel/test_mappings.py
@@ -178,8 +178,18 @@ def test_ReduceScatterToSequenceParallelRegion():
     output_data = mappings.reduce_scatter_to_sequence_parallel_region(input_data)
     expected_output = torch.ones(4).cuda() * 4 * int(Utils.rank % 4)
     assert torch.equal(output_data[0], expected_output)
+    deterministic_output_data = mappings.reduce_scatter_to_sequence_parallel_region(
+        input_data, deterministic=True
+    )
+    assert torch.equal(deterministic_output_data[0], expected_output)
     assert torch.equal(
         mappings._ReduceScatterToSequenceParallelRegion.symbolic(None, input_data, tp_group),
+        expected_output.reshape((1, 4)),
+    )
+    assert torch.equal(
+        mappings._DeterministicReduceScatterToSequenceParallelRegion.symbolic(
+            None, input_data, tp_group
+        ),
         expected_output.reshape((1, 4)),
     )
     input_data = torch.ones(4).cuda() * Utils.rank
@@ -196,4 +206,36 @@ def test_ReduceScatterToSequenceParallelRegion():
     if Utils.rank >= 4:
         expected_output = expected_output + 4
     assert torch.equal(output_data[0], expected_output)
+    deterministic_backward_data = mappings._DeterministicReduceScatterToSequenceParallelRegion.backward(
+        Ctx(), input_data
+    )
+    assert torch.equal(deterministic_backward_data[0], expected_output)
+
+    split_sizes = [1, 2, 3, 4]
+    rank_in_group = Utils.rank % 4
+    explicit_input = torch.arange(sum(split_sizes) * 4, dtype=torch.float32).reshape(-1, 4).cuda()
+    explicit_output = mappings.reduce_scatter_to_sequence_parallel_region(
+        explicit_input,
+        input_split_sizes=split_sizes,
+        deterministic=True,
+    )
+    explicit_start = sum(split_sizes[:rank_in_group])
+    explicit_expected = explicit_input[
+        explicit_start : explicit_start + split_sizes[rank_in_group]
+    ] * 4
+    assert torch.equal(explicit_output, explicit_expected)
+
+    class SplitCtx:
+        input_split_sizes = split_sizes
+        group = tp_group
+        use_global_buffer = False
+
+    explicit_grad = torch.ones((split_sizes[rank_in_group], 4), device="cuda") * rank_in_group
+    explicit_backward_data = mappings._DeterministicReduceScatterToSequenceParallelRegion.backward(
+        SplitCtx(), explicit_grad
+    )
+    explicit_backward_expected = torch.cat(
+        [torch.ones((split_size, 4)) * rank for rank, split_size in enumerate(split_sizes)]
+    ).cuda()
+    assert torch.equal(explicit_backward_data[0], explicit_backward_expected)
     Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/moe/test_moe_layer.py
+++ b/tests/unit_tests/transformer/moe/test_moe_layer.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -15,7 +17,70 @@ from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import is_te_min_version
 from megatron.training.initialize import _set_random_seed
+from miles_megatron_plugins.true_on_policy.moe_layer_ext import (
+    should_compact_true_on_policy_padding,
+    uses_true_on_policy_moe_kernel,
+)
 from tests.unit_tests.test_utilities import Utils
+
+
+class _FakeGroup:
+    def __init__(self, size: int):
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
+class _FakeExperts:
+    def forward_sglang_local_masked(self):
+        raise AssertionError("not called")
+
+
+def _make_true_on_policy_moe_layer_for_gate_tests(
+    *,
+    sequence_parallel: bool,
+    attn_tp_size: int,
+) -> MoELayer:
+    layer = object.__new__(MoELayer)
+    layer.config = SimpleNamespace(
+        true_on_policy_contract="qwen3_moe_true_on_policy_v1",
+        context_parallel_size=1,
+        cp_comm_type=None,
+        batch_invariant_mode=False,
+        expert_model_parallel_size=4,
+        sequence_parallel=sequence_parallel,
+        moe_latent_size=None,
+        moe_router_topk=8,
+        moe_permute_fusion=False,
+    )
+    layer.attn_tp_group = _FakeGroup(attn_tp_size)
+    layer.use_shared_expert = False
+    layer.token_dispatcher = SimpleNamespace(drop_and_pad=False, tp_size=1, ep_size=4)
+    layer.experts = _FakeExperts()
+    return layer
+
+
+def test_true_on_policy_moe_padding_compaction_disabled_for_sp():
+    layer = _make_true_on_policy_moe_layer_for_gate_tests(
+        sequence_parallel=True,
+        attn_tp_size=2,
+    )
+    padding_mask = torch.tensor([[False, True]])
+
+    assert not should_compact_true_on_policy_padding(layer, padding_mask, None)
+    assert uses_true_on_policy_moe_kernel(layer)
+
+
+def test_true_on_policy_moe_padding_compaction_kept_without_sp():
+    layer = _make_true_on_policy_moe_layer_for_gate_tests(
+        sequence_parallel=False,
+        attn_tp_size=1,
+    )
+    padding_mask = torch.tensor([[False, True]])
+
+    assert should_compact_true_on_policy_padding(layer, padding_mask, None)
+    assert uses_true_on_policy_moe_kernel(layer)
 
 
 class TestMoELayerInit:


### PR DESCRIPTION
Stacked on top of radixark/Megatron-LM#30.

## Summary

Adds the Megatron-LM training-side support for Qwen3-30B-A3B MoE SP+PP true-on-policy parity.

This PR is one of three coupled PRs that should be reviewed and landed together because they extend the `qwen3_moe_true_on_policy_v1` contract to allow Megatron sequence parallel and pipeline parallel training while preserving exact SGLang rollout parity.

**Companion PRs:**
- SGLang: https://github.com/sgl-project/sglang/pull/26317
- Miles: https://github.com/radixark/miles/pull/1088

## Main Changes

- Enable the true-on-policy MoE path under sequence parallel and pipeline parallel while preserving the narrow `qwen3_moe_true_on_policy_v1` contract gate.
- Add SP-aware tensor-parallel reduce-scatter/all-gather behavior needed by the Qwen3 MoE train/logprob path.
- Adjust MoE token dispatch/shared expert/local-masked expert handling so SP inputs do not use the incompatible padding-compaction path.
- Carry final residuals correctly through the PP schedule and transformer block path used by true-on-policy recompute/training.
- Update RMSNorm/batch-invariant residual handling and the shared schema flag for Megatron SP support.
- Keep debug-only helpers and unused defensive paths out of the final branch.

## Validation

Cleaned 8-GPU ion7 real-workload run:

- Run id: `moe_sppp_pr_tp2_pp2_ep2_onpolicy_real3_cleaned_noci_nosave_260524_ion7`
- Ray job: `raysubmit_a9NCtiu6K5dRVCsc`
- Topology: Megatron `TP=2`, `PP=2`, `EP=2`, `ETP=1`, sequence parallel enabled; SGLang 4 rollout engines, each `TP=2`, `EP=2`.
- Result: Ray job succeeded, all 8 GPUs returned to `0 MiB`.
- Step 1: `train/train_rollout_logprob_abs_diff=0.0`, `train/train_rollout_kl=0.0`, `grad_norm=0.0377418305`, weight version `1.0`, mixed version `0.0`.
- Step 2: `train/train_rollout_logprob_abs_diff=0.0`, `train/train_rollout_kl=0.0`, `grad_norm=0.0389085777`, weight version `2.0`, mixed version `0.0`.
- Timing: cleaned step times `485.2571s` and `462.8948s`, about `2.6-2.9%` slower than the previous on-policy no-debug timing run and in the same overhead band versus off-policy.

Focused checks after cleanup:

- [x] `git diff --check`
- [x] Miles fast checks: `53 passed`
- [x] Megatron targeted extension/MoE checks: `3 passed`
- [x] Megatron 8-rank tensor-parallel mapping check passed on all ranks
- [x] Full SP+PP 8-GPU E2E exact-logprob rerun on ion7

Local record:
`recovery/qwen3_moe_sppp_clean/journal/2026-05-23-sppp-e2e.md`
