### PR TITLE
Broaden packages.find.include to expose megatron.training

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,15 @@ build-backend = "setuptools.build_meta"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["megatron.core", "megatron.core.*"]
+# Expose megatron.training in addition to megatron.core so callers (e.g. the
+# miles training runner) can `pip install -e .` this checkout and import
+# from `megatron.training.*` without an explicit PYTHONPATH override.
+include = [
+    "megatron.core",
+    "megatron.core.*",
+    "megatron.training",
+    "megatron.training.*",
+]
 
 [tool.setuptools.dynamic]
 version = { attr = "megatron.core.package_info.__version__" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,13 @@ include-package-data = true
 # explicit PYTHONPATH override. (megatron.training.initialize imports from
 # megatron.legacy at module load, so any narrower include list breaks
 # transitively.)
+#
+# `namespaces = true` is required because `megatron`, `megatron.legacy`, and
+# several sub-packages are namespace packages (no `__init__.py`). Without
+# this, find_packages skips them and the editable install only works via the
+# side-effect that pip adds the project root to sys.path.
 include = ["megatron*"]
+namespaces = true
 
 [tool.setuptools.dynamic]
 version = { attr = "megatron.core.package_info.__version__" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,13 @@ build-backend = "setuptools.build_meta"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-# Expose megatron.training in addition to megatron.core so callers (e.g. the
-# miles training runner) can `pip install -e .` this checkout and import
-# from `megatron.training.*` without an explicit PYTHONPATH override.
-include = [
-    "megatron.core",
-    "megatron.core.*",
-    "megatron.training",
-    "megatron.training.*",
-]
+# Expose every `megatron.*` sub-package so callers (e.g. the miles training
+# runner) can `pip install -e .` this checkout and freely import from
+# `megatron.training`, `megatron.legacy`, `megatron.rl`, etc. without an
+# explicit PYTHONPATH override. (megatron.training.initialize imports from
+# megatron.legacy at module load, so any narrower include list breaks
+# transitively.)
+include = ["megatron*"]
 
 [tool.setuptools.dynamic]
 version = { attr = "megatron.core.package_info.__version__" }


### PR DESCRIPTION
## Summary
- Broaden `[tool.setuptools.packages.find].include` to also expose `megatron.training` and `megatron.training.*` (in addition to the existing `megatron.core` / `megatron.core.*`).

## Why
miles imports from several modules under `megatron.training.*` (`arguments`, `checkpointing`, `global_vars`, `tokenizer.tokenizer`, `training`). Until now those imports succeed only because `pip install -e .` adds the project root to `sys.path` as a side effect — not because `megatron.training` is an explicitly declared package.

miles' CPU CI runner makes that side effect explicit via `PYTHONPATH=$workspace/third_party/Megatron-LM`. That PYTHONPATH workaround doesn't survive packaging miles as a wheel (the eventual `pip install miles` goal in the broader Phase 2 roadmap).

Declaring `megatron.training.*` in the explicit package list lets a normal `pip install` (editable, wheel, or otherwise) expose it. No code in this PR changes; only the discovery list does.

## What this does NOT change
- Runtime semantics for code already importing from `megatron.training`: the same modules resolve.
- `megatron-core`'s project name. The wheel is still `megatron-core`, just with a slightly broader set of sub-packages.

## Test plan
- [ ] miles PR (linked below) bumps its `third_party/Megatron-LM` submodule pointer to this branch's HEAD and removes the `PYTHONPATH=$workspace/third_party/Megatron-LM` override from `_run-ci.yml`. CI on that PR is the validation gate: stage-a-fast (CPU runner) must pass — that's the path that previously needed the PYTHONPATH hack to find `megatron.training`.
- [ ] Smoke on H200 devbox with a rebuilt image: `unset PYTHONPATH && python -c "import megatron.training; import megatron.training.training"` succeeds.

## Stacked on
[radixark/Megatron-LM PR #32](https://github.com/radixark/Megatron-LM/pull/32) (Phase 1: remove `miles_megatron_plugins/`). After both this PR and #32 merge, the `miles-main` branch carries both changes; the miles repo's submodule pointer flips back to `branch = miles-main`.
