### PR TITLE
Package miles_megatron_plugins with Megatron Core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,12 @@ build-backend = "setuptools.build_meta"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["megatron.core", "megatron.core.*"]
+include = [
+    "megatron.core",
+    "megatron.core.*",
+    "miles_megatron_plugins",
+    "miles_megatron_plugins.*",
+]
 
 [tool.setuptools.dynamic]
 version = { attr = "megatron.core.package_info.__version__" }
@@ -187,7 +192,7 @@ emerging_optimizers = { git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizer
 profile = "black"                                                          # black-compatible
 line_length = 100                                                          # should match black parameters
 py_version = 310                                                           # python 3.8 as a target version
-known_first_party = ["megatron"]                                           # FIRSTPARTY section
+known_first_party = ["megatron", "miles_megatron_plugins"]                 # FIRSTPARTY section
 known_third_party = ["transformer_engine"]                                 # THIRDPARTY section
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
 default_section = "THIRDPARTY"


### PR DESCRIPTION
## Summary

- include `miles_megatron_plugins` in Megatron-LM setuptools package discovery
- classify `miles_megatron_plugins` as first-party for isort

## Why

`miles-main` imports `miles_megatron_plugins.true_on_policy` from Megatron Core, but `pip install -e .` only exposed `megatron.core*`. This means fresh CI environments can fail with `ModuleNotFoundError: No module named 'miles_megatron_plugins'` even though the source directory exists in the Megatron-LM checkout.

This keeps the true-on-policy plugin owned by Megatron-LM instead of vendoring it into `radixark/miles`. Related: radixark/miles#1259.

## Verification

Ran a setuptools namespace discovery check from the repo root and confirmed the package set includes:

- `megatron.core`
- `megatron.core.transformer`
- `miles_megatron_plugins`
- `miles_megatron_plugins.true_on_policy`

Also ran `git diff --check`.
