### PR TITLE
Broaden megatron-core packages.find to megatron* (namespaces), keep plugins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,19 @@ build-backend = "setuptools.build_meta"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = [
-    "megatron.core",
-    "megatron.core.*",
-    "miles_megatron_plugins",
-    "miles_megatron_plugins.*",
-]
+# Expose every `megatron.*` sub-package so callers (e.g. the miles training
+# runner) can `pip install -e .` this checkout and freely import from
+# `megatron.training`, `megatron.legacy`, `megatron.rl`, etc. without an
+# explicit PYTHONPATH override. (megatron.training.initialize imports from
+# megatron.legacy at module load, so any narrower include list breaks
+# transitively.)
+#
+# `namespaces = true` is required because `megatron`, `megatron.legacy`, and
+# several sub-packages are namespace packages (no `__init__.py`). Without
+# this, find_packages skips them and the editable install only works via the
+# side-effect that pip adds the project root to sys.path.
+include = ["megatron*", "miles_megatron_plugins", "miles_megatron_plugins.*"]
+namespaces = true
 
 [tool.setuptools.dynamic]
 version = { attr = "megatron.core.package_info.__version__" }


### PR DESCRIPTION
## Summary
Builds on the merged #49 (`Package miles_megatron_plugins with Megatron Core`) by broadening `[tool.setuptools.packages.find].include` from `megatron.core*` to `megatron*` with `namespaces = true`, while keeping `miles_megatron_plugins` in the include list.

This lets callers (e.g. the miles training runner) `pip install -e .` this checkout and import from `megatron.training`, `megatron.legacy`, `megatron.rl`, etc. without a `PYTHONPATH` override — `megatron.training.initialize` imports from `megatron.legacy` at module load, so a narrower include list breaks transitively. `namespaces = true` is required because `megatron`, `megatron.legacy`, and several sub-packages are PEP-420 namespace packages (no `__init__.py`).

## Why
The miles submoduling stack pins this repo as `third_party/Megatron-LM` and bundles both `megatron.*` and `miles_megatron_plugins` into the `miles-rl` wheel directly from the submodule. That requires the source checkout to expose the full `megatron*` tree (not just `megatron.core`) and to keep packaging the plugins. This PR reconciles both needs in one place, on top of the current `miles-main` (post-#49).

## Supersedes
Replaces the obsolete pair:
- #32 (`Remove miles_megatron_plugins/`) — contradicts #49; we keep the plugins inside Megatron-LM.
- #33 (`Broaden packages.find.include`) — folded into this single commit on top of the current `miles-main`.

## Test plan
- [ ] `pip install -e .` on this checkout, then `python -c "import megatron.training, megatron.legacy, miles_megatron_plugins"` with no `PYTHONPATH` override
- [ ] Build the `miles-rl` wheel from the miles submoduling stack and confirm `megatron*` + `miles_megatron_plugins` land at the top level of site-packages
