### PR TITLE
fix(gdn): only reject THD packed_seq_params, allow BSHD

### DIFF
--- a/megatron/core/ssm/gated_delta_net.py
+++ b/megatron/core/ssm/gated_delta_net.py
@@ -295,9 +295,10 @@ class GatedDeltaNet(MegatronModule):
             # TODO: support inference
             raise NotImplementedError("GDN does not support inference for now.")
 
-        if packed_seq_params is not None:
-            # TODO: support packed sequence
-            raise NotImplementedError("GDN does not support packed sequence for now.")
+        if packed_seq_params is not None and packed_seq_params.qkv_format == "thd":
+            # GDN ignores the bshd PackedSeqParams Megatron passes uniformly; only genuine
+            # THD packing is unsupported (TODO: port THD support from upstream PR #2645).
+            raise NotImplementedError("GDN does not support THD packed sequence for now.")
 
         # Input projection
         nvtx_range_push(suffix="in_proj")


### PR DESCRIPTION
## Problem
`GatedDeltaNet.forward` blanket-rejects any non-None `packed_seq_params`, but Megatron passes a `PackedSeqParams` object to every attention module uniformly — even in BSHD mode (`qkv_format="bshd"`). This crashes Qwen3.5/3.6 GDN with `NotImplementedError: GDN does not support packed sequence for now.`

## Fix
Guard on `packed_seq_params.qkv_format == "thd"` specifically, matching upstream NVIDIA/Megatron-LM PR #2645. BSHD now proceeds (GDN ignores the params and computes seq_len from shapes); genuine THD packing still raises (full THD support is a follow-up port of PR #2645).

## Validation
Built the real `GatedDeltaNet` on GPU and exercised the guard with real `PackedSeqParams`:
- before: BSHD → `GDN does not support packed sequence`
- after: BSHD passes the guard and completes a full forward; THD still raises.

Fixes radixark/miles#1292