### PR TITLE
fix(dist-ckpt): handle bare BytesIO _extra_state in key recovery (TE FP8)

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -385,6 +385,10 @@ def _replace_sharded_keys_with_state_dict_keys(
     """Inverse of _replace_state_dict_keys_with_sharded_keys."""
     recovered_sd = {}
     for k, tensors in state_dict.items():
+        if isinstance(tensors, io.BytesIO):
+            # TE FP8 _extra_state arrives as a bare io.BytesIO, so len(tensors) raises.
+            # An empty uint8 tensor makes TE.set_extra_state skip restoring FP8 state.
+            tensors = [torch.empty(0, dtype=torch.uint8)]
         assert len(tensors) == len(rename_mapping[k])
         for ten, recovered_k in zip(tensors, rename_mapping[k]):
             recovered_sd[recovered_k] = ten


### PR DESCRIPTION
## Problem
Loading a TransformerEngine FP8 distributed checkpoint crashes in `_replace_sharded_keys_with_state_dict_keys`: TE stores `_extra_state` as a bare `io.BytesIO`, which `_unwrap_pyt_sharded_tensor` returns unwrapped, so `assert len(tensors) == ...` raises `TypeError: object of type 'BytesIO' has no len()`. (Upstream NVIDIA/Megatron-LM has the same unpatched code — this is a carried fix, not a sync gap.)

## Fix
When the value is a bare `io.BytesIO`, substitute an empty `uint8` tensor. TE's `set_extra_state` treats an empty tensor as "no FP8 state to restore" (early return), which is correct for RL training where FP8 is not used.

## Validation
Routed a realistic BytesIO `_extra_state` (torch.save into io.BytesIO) through the exact recovery function:
- before: `len(BytesIO)` → TypeError reproduced
- after: substituted empty uint8 tensor, no crash; a real TE module accepts it via `set_extra_state`.

Fixes radixark/miles#1293