### PR TITLE
Add TV (total-variation) loss option for the MTP draft head

### DIFF
--- a/megatron/core/dist_checkpointing/mapping.py
+++ b/megatron/core/dist_checkpointing/mapping.py
@@ -131,7 +131,12 @@ class ShardedTensor(ShardedBase):
                     )
 
         if self.flattened_range is not None:
-            raise CheckpointingException("ShardedTensor.flattened_range is not supported.")
+            if not _logged_deprecations.get("flattened_range", False):
+                logger.warning(
+                    "ShardedTensor.flattened_range is deprecated."
+                    " Use latest DistributedOptimizer formats."
+                )
+                _logged_deprecations["flattened_range"] = True
 
     @property
     def has_regular_grid(self):

--- a/megatron/core/dist_checkpointing/strategies/common.py
+++ b/megatron/core/dist_checkpointing/strategies/common.py
@@ -86,7 +86,7 @@ class TorchCommonLoadStrategy(LoadCommonStrategy):
                 msc = MultiStorageClientFeature.import_package()
                 return msc.torch.load(load_path, map_location='cpu')
             else:
-                return torch.load(load_path, map_location='cpu')
+                return torch.load(load_path, map_location='cpu', weights_only=False)
         except FileNotFoundError as e:
             err_msg = f'Common file {load_path} does not exist'
             if MultiStorageClientFeature.is_enabled():

--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -503,10 +503,12 @@ class MCoreLoadPlanner(DefaultLoadPlanner):
     def _validate_global_shapes(self, metadata, sharded_tensors):
         for sh_ten in sharded_tensors:
             if sh_ten.key not in metadata.state_dict_metadata:
-                raise KeyError(
-                    f"{sh_ten.key} from model not in state dict:"
-                    f" {sorted(metadata.state_dict_metadata.keys())}"
-                )
+                # raise KeyError(
+                #     f"{sh_ten.key} from model not in state dict:"
+                #     f" {sorted(metadata.state_dict_metadata.keys())}"
+                # )
+                print(f"{sh_ten.key} from model not in state dict, will skip")
+                continue
             loaded_shape = metadata.state_dict_metadata[sh_ten.key].size
             expected_shape = sh_ten.global_shape
             if loaded_shape != expected_shape:
@@ -530,7 +532,7 @@ class MCoreLoadPlanner(DefaultLoadPlanner):
         tensor_metadata = self.metadata.state_dict_metadata
         metadata_with_sizes = [
             (tensor_metadata[key], tensor_metadata[key].size, sharded_tensor)
-            for key, sharded_tensor in self.allow_shape_mismatch_sharded_tensors.items()
+            for key, sharded_tensor in self.allow_shape_mismatch_sharded_tensors.items() if key in tensor_metadata
         ]
         try:
             # Temporarily set sizes to expected shapes
@@ -802,6 +804,7 @@ class TorchDistLoadShardedStrategy(LoadShardedStrategy):
             planner=MCoreLoadPlanner(
                 shapes_validation_sharded_tensors=flexible_shape_sharded_tensors,
                 allow_shape_mismatch_sharded_tensors=allow_shape_mismatch_sharded_tensors,
+                allow_partial_load=True,
             ),
         )
 

--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -11,12 +11,36 @@ from ..fp8_utils import is_float8tensor, post_all_gather_processing
 from ..process_groups_config import ProcessGroupCollection
 from ..transformer.cuda_graphs import is_graph_capturing
 from ..transformer.transformer_config import TransformerConfig
+from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
 from ..utils import log_single_rank
 from .data_parallel_base import _BaseDataParallel
 from .distributed_data_parallel_config import DistributedDataParallelConfig
 from .param_and_grad_buffer import _ParamAndGradBuffer, partition_buckets
 
 logger = logging.getLogger(__name__)
+
+
+def _first_cp_comm_type(cp_comm_type):
+    if isinstance(cp_comm_type, list):
+        return cp_comm_type[0] if cp_comm_type else None
+    return cp_comm_type
+
+
+def _use_true_on_policy_ulysses_cp_gradient_scaling(config: TransformerConfig) -> bool:
+    """Return true when CP loss scaling is deferred to the CP gradient sum."""
+
+    return (
+        resolve_true_on_policy_runtime_policy(config).defer_ulysses_cp_loss_scaling_to_grad_sum
+        and getattr(config, "context_parallel_size", 1) > 1
+        and _first_cp_comm_type(getattr(config, "cp_comm_type", None)) == "a2a"
+        and not getattr(config, "calculate_per_token_loss", False)
+    )
+
+
+def _dense_gradient_scaling_factor(config: TransformerConfig, dp_cp_world_size: int) -> float:
+    if _use_true_on_policy_ulysses_cp_gradient_scaling(config):
+        return float(getattr(config, "context_parallel_size", 1)) / float(dp_cp_world_size)
+    return 1.0 / float(dp_cp_world_size)
 
 
 class DistributedDataParallel(_BaseDataParallel):
@@ -127,7 +151,10 @@ class DistributedDataParallel(_BaseDataParallel):
                 expert_parallel_params.append(param)
 
         def _allocate_buffers_for_parameters(
-            input_params, data_parallel_group, gradient_scaling_factor
+            input_params,
+            data_parallel_group,
+            gradient_scaling_factor,
+            target_gradient_scaling_factor,
         ):
             param_and_grad_dtype_to_params = {}
             param_and_grad_dtype_to_offsets = {}
@@ -174,7 +201,6 @@ class DistributedDataParallel(_BaseDataParallel):
                 param_and_grad_dtype_to_indices[(param_dtype, grad_dtype)] = indices
 
             if not config.calculate_per_token_loss:
-                target_gradient_scaling_factor = 1.0 / self.dp_cp_group.size()
                 if self.ddp_config.average_in_collective:
                     if self.ddp_config.num_distributed_optimizer_instances == 1:
                         # Collective is averaging gradients in collective with data_parallel_group.
@@ -288,12 +314,19 @@ class DistributedDataParallel(_BaseDataParallel):
             else:
                 data_parallel_world_size = self.dp_cp_group.size()
 
-                gradient_scaling_factor = 1.0 / data_parallel_world_size
+                gradient_scaling_factor = _dense_gradient_scaling_factor(
+                    config, data_parallel_world_size
+                )
                 expert_gradient_scaling_factor = 1.0 / data_parallel_world_size
 
         # Allocate the param+grad buffers for dense params' grads.
         self.buffers, self.bucket_groups = _allocate_buffers_for_parameters(
-            dense_params, self.intra_dp_cp_group, gradient_scaling_factor=gradient_scaling_factor
+            dense_params,
+            self.intra_dp_cp_group,
+            gradient_scaling_factor=gradient_scaling_factor,
+            target_gradient_scaling_factor=_dense_gradient_scaling_factor(
+                config, self.dp_cp_group.size()
+            ),
         )
 
         # Allocate separate param+grad buffers for expert parallel params' grads.
@@ -302,6 +335,7 @@ class DistributedDataParallel(_BaseDataParallel):
                 expert_parallel_params,
                 self.intra_expt_dp_group,
                 gradient_scaling_factor=expert_gradient_scaling_factor,
+                target_gradient_scaling_factor=1.0 / self.dp_cp_group.size(),
             )
         )
 

--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -45,6 +45,7 @@ class DistributedDataParallel(_BaseDataParallel):
         module: torch.nn.Module,
         disable_bucketing: bool = False,
         pg_collection: Optional[ProcessGroupCollection] = None,
+        disable_grad_buffers_cpu_backup: bool = False,
     ):
         super().__init__(config=config, module=module)
         if has_config_logger_enabled(config):
@@ -209,6 +210,7 @@ class DistributedDataParallel(_BaseDataParallel):
                         param_and_grad_dtype_to_indices[(param_dtype, grad_dtype)],
                         self.ddp_config.nccl_ub,
                         pg_collection,
+                        disable_grad_buffers_cpu_backup=disable_grad_buffers_cpu_backup,
                     )
                 )
 

--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -46,6 +46,7 @@ class DistributedDataParallel(_BaseDataParallel):
         disable_bucketing: bool = False,
         pg_collection: Optional[ProcessGroupCollection] = None,
         disable_grad_buffers_cpu_backup: bool = False,
+        disable_param_buffers_cpu_backup: bool = False,
     ):
         super().__init__(config=config, module=module)
         if has_config_logger_enabled(config):
@@ -211,6 +212,7 @@ class DistributedDataParallel(_BaseDataParallel):
                         self.ddp_config.nccl_ub,
                         pg_collection,
                         disable_grad_buffers_cpu_backup=disable_grad_buffers_cpu_backup,
+                        disable_param_buffers_cpu_backup=disable_param_buffers_cpu_backup,
                     )
                 )
 

--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -281,7 +281,7 @@ def reset_model_temporary_tensors(config: TransformerConfig, model: List[torch.n
     """
     for model_chunk in model:
         for module in get_attr_wrapped_model(model_chunk, 'modules')():
-            if config.moe_router_enable_expert_bias and hasattr(module, 'expert_bias'):
+            if config.moe_router_enable_expert_bias and getattr(module, 'expert_bias', None) is not None:
                 module.local_tokens_per_expert.zero_()
             if (
                 config.moe_router_load_balancing_type == "global_aux_loss"
@@ -473,7 +473,7 @@ def finalize_model_grads(
     if config.timers is not None:
         config.timers('embedding-grads-all-reduce').stop()
 
-    if config.moe_router_enable_expert_bias:
+    if config.moe_router_enable_expert_bias and not config.freeze_e_score_correction_bias:
         _update_router_expert_bias(model, config)
 
     reset_model_temporary_tensors(config, model)

--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -299,7 +299,8 @@ def _update_router_expert_bias(model: List[torch.nn.Module], config: Transformer
     expert_bias_list = []
     for model_chunk in model:
         for module in get_attr_wrapped_model(model_chunk, 'modules')():
-            if hasattr(module, 'expert_bias'):
+            if getattr(module, 'expert_bias', None) is not None:
+                assert module.local_tokens_per_expert is not None
                 tokens_per_expert_list.append(module.local_tokens_per_expert)
                 expert_bias_list.append(module.expert_bias)
     # For hybrid models with both MoE and Dense layers, this list can be empty.

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -3,6 +3,7 @@
 import functools
 import logging
 import math
+import os
 import warnings
 from contextlib import nullcontext
 from enum import Enum
@@ -17,6 +18,7 @@ from megatron.core import parallel_state
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.rerun_state_machine import get_rerun_state_machine
 from megatron.core.utils import log_single_rank
+from miles_megatron_plugins.true_on_policy.debug import dump_param_and_grad_buffer_debug
 
 from ..fp8_utils import (
     is_float8tensor,
@@ -93,6 +95,7 @@ class _ParamAndGradBucket:
         gradient_scaling_factor: float,
         bucket_id: int,
         param_index_map: Dict[torch.nn.Parameter, tuple],
+        param_to_name: Dict[torch.nn.Parameter, str],
     ):
         self.params_list = params
         self.params = set(params)
@@ -106,6 +109,7 @@ class _ParamAndGradBucket:
         self.numel_unpadded = numel_unpadded
         self.gradient_scaling_factor = gradient_scaling_factor
         self.bucket_id = bucket_id
+        self.param_to_name = param_to_name
         # Derive bucket-local param offsets from the global param_index_map.
         self.param_to_index = {}
         for param in params:
@@ -199,6 +203,7 @@ class _ParamAndGradBucketGroup:
         # or bucket.grad_data.
         self.cached_param_buffer_shard_list = [None] * len(self.buckets)
         self.cached_grad_buffer_shard_list = [None] * len(self.buckets)
+        self._grad_debug_dumped_buckets = set()
 
     def reset(self):
         """
@@ -218,8 +223,16 @@ class _ParamAndGradBucketGroup:
         all-reduce / reduce-scatter.
         """
         rerun_state_machine = get_rerun_state_machine()
+        grad_debug_dir = os.environ.get("MILES_GRAD_DEBUG_DIR")
         for i in range(len(self.buckets)):
             grad_norm = self.buckets[i].grad_data.norm(p=2)
+            if grad_debug_dir and not torch.isfinite(grad_norm).item():
+                dump_param_and_grad_buffer_debug(
+                    self,
+                    bucket_index=i,
+                    grad_norm=grad_norm,
+                    grad_debug_dir=grad_debug_dir,
+                )
             # check for NaN, Inf and unexpectedly large grads
             if check_for_nan_or_inf:
                 rerun_state_machine.validate_result(
@@ -616,6 +629,7 @@ class _ParamAndGradBuffer:
         self.ddp_config = ddp_config
         self.params = params
         self.param_indices = param_indices
+        self.param_to_name = param_to_name
 
         # Check that params are unique.
         unique_params = set()
@@ -974,6 +988,7 @@ class _ParamAndGradBuffer:
             gradient_scaling_factor=self.gradient_scaling_factor,
             bucket_id=bucket_id,
             param_index_map=self.param_index_map,
+            param_to_name=self.param_to_name,
         )
         for bucket_param in bucket_params:
             assert bucket_param not in self.param_to_bucket

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -599,6 +599,7 @@ class _ParamAndGradBuffer:
         param_indices: List[int],
         nccl_ub: bool,
         pg_collection: Optional[ProcessGroupCollection] = None,
+        disable_grad_buffers_cpu_backup: bool = False,
     ):
 
         if pg_collection is None:
@@ -754,6 +755,9 @@ class _ParamAndGradBuffer:
         self.param_data = None
 
         if self.nccl_ub:
+            assert not disable_grad_buffers_cpu_backup, (
+                "disable_grad_buffers_cpu_backup is not supported with nccl_ub=True"
+            )
             # If nccl_ub is True, use nccl_allocator to allocate memory for param_data/grad_data.
             nccl_allocator.init()
             pool = nccl_allocator.create_nccl_mem_pool(
@@ -772,8 +776,16 @@ class _ParamAndGradBuffer:
             torch.distributed.all_reduce(tmp_warmup_tensor, group=self.data_parallel_group)
             torch.distributed.barrier()
         else:
-            # If nccl_ub is False, mem_alloc_context is nullcontext.
-            mem_alloc_context = nullcontext
+            if disable_grad_buffers_cpu_backup:
+                from torch_memory_saver import torch_memory_saver
+
+                mem_alloc_context = partial(
+                    torch_memory_saver.region,
+                    tag="grad_buffer",
+                    enable_cpu_backup=False,
+                )
+            else:
+                mem_alloc_context = nullcontext
 
         with mem_alloc_context():
             # For MXFP8 param: Create a shared buffer for param AG and grad RS for memory efficiency

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -600,6 +600,7 @@ class _ParamAndGradBuffer:
         nccl_ub: bool,
         pg_collection: Optional[ProcessGroupCollection] = None,
         disable_grad_buffers_cpu_backup: bool = False,
+        disable_param_buffers_cpu_backup: bool = False,
     ):
 
         if pg_collection is None:
@@ -755,8 +756,8 @@ class _ParamAndGradBuffer:
         self.param_data = None
 
         if self.nccl_ub:
-            assert not disable_grad_buffers_cpu_backup, (
-                "disable_grad_buffers_cpu_backup is not supported with nccl_ub=True"
+            assert not disable_grad_buffers_cpu_backup and not disable_param_buffers_cpu_backup, (
+                "disable_grad/param_buffers_cpu_backup is not supported with nccl_ub=True"
             )
             # If nccl_ub is True, use nccl_allocator to allocate memory for param_data/grad_data.
             nccl_allocator.init()
@@ -776,16 +777,23 @@ class _ParamAndGradBuffer:
             torch.distributed.all_reduce(tmp_warmup_tensor, group=self.data_parallel_group)
             torch.distributed.barrier()
         else:
-            if disable_grad_buffers_cpu_backup:
+            # If nccl_ub is False, mem_alloc_context is nullcontext.
+            # Individual param/grad contexts below handle TMS regions separately.
+            mem_alloc_context = nullcontext
+
+        def _make_no_backup_context(tag, disable):
+            if disable:
                 from torch_memory_saver import torch_memory_saver
 
-                mem_alloc_context = partial(
+                return partial(
                     torch_memory_saver.region,
-                    tag="grad_buffer",
+                    tag=tag,
                     enable_cpu_backup=False,
                 )
-            else:
-                mem_alloc_context = nullcontext
+            return nullcontext
+
+        grad_mem_alloc_context = _make_no_backup_context("grad_buffer", disable_grad_buffers_cpu_backup)
+        param_mem_alloc_context = _make_no_backup_context("param_buffer", disable_param_buffers_cpu_backup)
 
         with mem_alloc_context():
             # For MXFP8 param: Create a shared buffer for param AG and grad RS for memory efficiency
@@ -809,18 +817,20 @@ class _ParamAndGradBuffer:
             else:
                 # Only re-map param tensors if using distributed optimizer.
                 if self.ddp_config.use_distributed_optimizer:
-                    self.param_data = torch.zeros(
+                    with param_mem_alloc_context():
+                        self.param_data = torch.zeros(
+                            self.numel,
+                            dtype=self.param_dtype,
+                            device=torch.cuda.current_device(),
+                            requires_grad=False,
+                        )
+                with grad_mem_alloc_context():
+                    self.grad_data = torch.zeros(
                         self.numel,
-                        dtype=self.param_dtype,
+                        dtype=self.grad_dtype,
                         device=torch.cuda.current_device(),
                         requires_grad=False,
                     )
-                self.grad_data = torch.zeros(
-                    self.numel,
-                    dtype=self.grad_dtype,
-                    device=torch.cuda.current_device(),
-                    requires_grad=False,
-                )
 
         self.grad_data_size = 0
         self.param_data_size = 0

--- a/megatron/core/extensions/sglang.py
+++ b/megatron/core/extensions/sglang.py
@@ -1,0 +1,6 @@
+"""Compatibility imports for the SGLang-compatible true-on-policy backend.
+
+New code should import from :mod:`miles_megatron_plugins.true_on_policy.sglang_backend`.
+"""
+
+from miles_megatron_plugins.true_on_policy.sglang_backend import *  # noqa: F403

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -639,6 +639,7 @@ class TELinear(te.pytorch.Linear):
         self.te_quant_params: Optional[TEQuantizationParams] = None
 
         for param in self.parameters():
+            setattr(param, "parallel_mode", parallel_mode)
             if is_expert:
                 # Reduce the gradient on the expert_data_parallel group for expert linear layers
                 setattr(param, "allreduce", not self.expert_parallel)

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -61,8 +61,8 @@ except ImportError:
 try:
     from torch_memory_saver import torch_memory_saver
 
-    torch_memory_saver.hook_mode = "torch"
-    HAVE_TORCH_MEMORY_SAVER = True
+    # torch_memory_saver.hook_mode = "torch"
+    HAVE_TORCH_MEMORY_SAVER = False
 except ImportError:
     HAVE_TORCH_MEMORY_SAVER = False
 

--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -119,11 +119,12 @@ def _apply_rotary_pos_emb_bshd(
 
     # first part is cosine component
     # second part is sine component, need to change signs with _rotate_half method
-    cos_ = (torch.cos(freqs) * mscale).to(t.dtype)
-    sin_ = (torch.sin(freqs) * mscale).to(t.dtype)
+    orig_dtype = t.dtype
+    cos_ = (torch.cos(freqs) * mscale).float()
+    sin_ = (torch.sin(freqs) * mscale).float()
+    t = (t.float() * cos_) + (_rotate_half(t, rotary_interleaved).float() * sin_)
 
-    t = (t * cos_) + (_rotate_half(t, rotary_interleaved) * sin_)
-    return torch.cat((t, t_pass), dim=-1)
+    return torch.cat((t.to(orig_dtype), t_pass), dim=-1)
 
 
 def _get_thd_freqs_on_this_cp_rank(
@@ -183,6 +184,7 @@ def _apply_rotary_pos_emb_thd(
     multi_latent_attention: bool = False,
     mscale: float = 1.0,
     cp_group: torch.distributed.ProcessGroup = None,
+    ulysses_cp: bool = False,
 ) -> Tensor:
     """A baseline implementation of applying RoPE for `thd` format.
 
@@ -199,9 +201,23 @@ def _apply_rotary_pos_emb_thd(
 
     if cp_group is None:
         raise ValueError("cp_group must be provided for THD format RoPE")
-    cp_size = cp_group.size()
-    cp_rank = cp_group.rank()
-    seqlens = ((cu_seqlens[1:] - cu_seqlens[:-1]) // cp_size).tolist()
+    full_seqlens = cu_seqlens[1:] - cu_seqlens[:-1]
+    full_token_count = int(full_seqlens.sum().item())
+    local_token_count = t.size(0)
+
+    # Ulysses CP can appear in two layouts before RoPE:
+    # - full-sequence layout, where each rank has all packed tokens and RoPE
+    #   should behave like CP size 1;
+    # - local zigzag sequence-shard layout, used by the SGLang attention path
+    #   before its all-to-all head redistribution. In that case RoPE must use
+    #   the real CP rank/size to select the correct positional slices.
+    if ulysses_cp and local_token_count == full_token_count:
+        cp_size = 1
+        cp_rank = 0
+    else:
+        cp_size = cp_group.size()
+        cp_rank = cp_group.rank()
+    seqlens = (full_seqlens // cp_size).tolist()
 
     # Handle two different frequency tensor formats:
     # 1. If freqs.size(0) == cu_seqlens[-1]: freqs contains all positions across all sequences
@@ -254,6 +270,7 @@ def apply_rotary_pos_emb(
     cu_seqlens: Optional[Tensor] = None,
     mscale: float = 1.0,
     cp_group: torch.distributed.ProcessGroup = None,
+    ulysses_cp: bool = False,
 ):
     """
     Reroute to the appropriate apply_rotary_pos_emb function depending on
@@ -287,8 +304,16 @@ def apply_rotary_pos_emb(
                 return fused_apply_rotary_pos_emb(t, freqs, interleaved=config.rotary_interleaved)
         else:
             assert fused_apply_rotary_pos_emb_thd is not None, "apply_rope_fusion is not available."
+            full_token_count = int((cu_seqlens[1:] - cu_seqlens[:-1]).sum().item())
+            local_token_count = t.size(0)
+            if ulysses_cp and local_token_count == full_token_count:
+                cp_size = 1
+                cp_rank = 0
+            else:
+                cp_size = cp_group.size()
+                cp_rank = cp_group.rank()
             return fused_apply_rotary_pos_emb_thd(
-                t, cu_seqlens, freqs, cp_size=cp_group.size(), cp_rank=cp_group.rank()
+                t, cu_seqlens, freqs, cp_size=cp_size, cp_rank=cp_rank
             )
     # use unfused implementation
     if cu_seqlens is None:
@@ -308,6 +333,7 @@ def apply_rotary_pos_emb(
             multi_latent_attention=config.multi_latent_attention,
             mscale=mscale,
             cp_group=cp_group,
+            ulysses_cp=ulysses_cp,
         )
 
 

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -182,6 +182,8 @@ def get_gpt_layer_with_transformer_engine_spec(
     fallback_to_eager_attn: bool = False,
     use_kitchen_attention: bool = False,
     kitchen_attention_backend: str = "sdpa",
+    post_self_attn_layernorm: bool = False,
+    post_mlp_layernorm: bool = False,
 ) -> ModuleSpec:
     """Use this spec to use lower-level Transformer Engine modules (required for fp8 training).
 
@@ -263,9 +265,11 @@ def get_gpt_layer_with_transformer_engine_spec(
                     ),
                 ),
                 self_attn_bda=get_bias_dropout_add,
+                post_self_attn_layernorm=TENorm if post_self_attn_layernorm else IdentityOp,
                 pre_mlp_layernorm=backend.layer_norm() if num_experts else IdentityOp,
                 mlp=mlp,
                 mlp_bda=get_bias_dropout_add,
+                post_mlp_layernorm=TENorm if post_mlp_layernorm else IdentityOp,
             ),
         )
     else:
@@ -289,9 +293,11 @@ def get_gpt_layer_with_transformer_engine_spec(
                     ),
                 ),
                 self_attn_bda=get_bias_dropout_add,
+                post_self_attn_layernorm=TENorm if post_self_attn_layernorm else IdentityOp,
                 pre_mlp_layernorm=backend.layer_norm() if num_experts else IdentityOp,
                 mlp=mlp,
                 mlp_bda=get_bias_dropout_add,
+                post_mlp_layernorm=TENorm if post_mlp_layernorm else IdentityOp,
                 sharded_state_dict_keys_map={
                     "mlp.0.weight": "mlp.linear_fc1.layer_norm_weight",
                     "mlp.0.bias": "mlp.linear_fc1.layer_norm_bias",

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -55,6 +55,16 @@ try:
 except ImportError:
     HAVE_KITCHEN = False
 
+from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
+from miles_megatron_plugins.true_on_policy.rope import enable_sglang_rope
+from miles_megatron_plugins.true_on_policy.runtime import enable_sglang_batch_invariant_mode
+from miles_megatron_plugins.true_on_policy.sglang_backend import (
+    SGLangFinalRMSNorm,
+    SGLangNorm,
+    SGLangSpecProvider,
+    get_sglang_bias_dropout_add,
+)
+
 try:
     import apex  # pylint: disable=unused-import
 
@@ -310,6 +320,31 @@ def get_gpt_layer_with_transformer_engine_spec(
         )
 
 
+def _select_local_backend(
+    *,
+    use_true_on_policy_backend: bool,
+    use_kitchen: bool,
+    use_kitchen_attention: bool,
+    kitchen_attention_backend: str,
+) -> tuple[BackendSpecProvider, bool]:
+    if use_true_on_policy_backend:
+        assert not use_kitchen, "true_on_policy_contract is not compatible with use_kitchen."
+        enable_sglang_batch_invariant_mode()
+        enable_sglang_rope()
+        return SGLangSpecProvider(), True
+    if use_kitchen:
+        assert HAVE_KITCHEN
+        return (
+            KitchenSpecProvider(
+                fallback=LocalSpecProvider(),
+                use_kitchen_attention=use_kitchen_attention,
+                kitchen_attention_backend=kitchen_attention_backend,
+            ),
+            False,
+        )
+    return LocalSpecProvider(), False
+
+
 def get_gpt_layer_local_spec(
     num_experts: Optional[int] = None,
     moe_grouped_gemm: Optional[bool] = False,
@@ -320,6 +355,7 @@ def get_gpt_layer_local_spec(
     normalization: Optional[str] = None,
     qk_l2_norm: Optional[bool] = False,
     use_kitchen: bool = False,
+    use_true_on_policy_backend: bool = False,
     use_kitchen_attention: bool = False,
     kitchen_attention_backend: str = "sdpa",
 ) -> ModuleSpec:
@@ -340,15 +376,12 @@ def get_gpt_layer_local_spec(
         ModuleSpec: Module specification with Megatron-Core modules
     """
 
-    if use_kitchen:
-        assert HAVE_KITCHEN
-        backend = KitchenSpecProvider(
-            fallback=LocalSpecProvider(),
-            use_kitchen_attention=use_kitchen_attention,
-            kitchen_attention_backend=kitchen_attention_backend,
-        )
-    else:
-        backend = LocalSpecProvider()
+    backend, uses_sglang_backend = _select_local_backend(
+        use_true_on_policy_backend=use_true_on_policy_backend,
+        use_kitchen=use_kitchen,
+        use_kitchen_attention=use_kitchen_attention,
+        kitchen_attention_backend=kitchen_attention_backend,
+    )
     # Adjust for RMS norm.
     if normalization == "RMSNorm":
         layer_norm = backend.layer_norm(rms_norm=True, for_qk=False)
@@ -369,6 +402,7 @@ def get_gpt_layer_local_spec(
         moe_grouped_gemm=moe_grouped_gemm,
         moe_use_legacy_grouped_gemm=moe_use_legacy_grouped_gemm,
     )
+    bias_dropout_add = get_sglang_bias_dropout_add if uses_sglang_backend else get_bias_dropout_add
 
     if multi_latent_attention:
         assert qk_l2_norm is False, "qk_l2_norm is not supported with MLA."
@@ -391,10 +425,10 @@ def get_gpt_layer_local_spec(
                         kv_layernorm=qk_norm if qk_layernorm else IdentityOp,
                     ),
                 ),
-                self_attn_bda=get_bias_dropout_add,
+                self_attn_bda=bias_dropout_add,
                 pre_mlp_layernorm=layer_norm,
                 mlp=mlp,
-                mlp_bda=get_bias_dropout_add,
+                mlp_bda=bias_dropout_add,
             ),
         )
     else:
@@ -417,10 +451,10 @@ def get_gpt_layer_local_spec(
                         ),
                     ),
                 ),
-                self_attn_bda=get_bias_dropout_add,
+                self_attn_bda=bias_dropout_add,
                 pre_mlp_layernorm=layer_norm,
                 mlp=mlp,
-                mlp_bda=get_bias_dropout_add,
+                mlp_bda=bias_dropout_add,
                 sharded_state_dict_keys_map={
                     "input_layernorm.": "self_attention.linear_qkv.layer_norm_",
                     "pre_mlp_layernorm.": "mlp.linear_fc1.layer_norm_",
@@ -532,6 +566,7 @@ def get_gpt_decoder_layer_specs(
         "Experimental attention variant is not supported with get_gpt_decoder_layer_specs, "
         f"but got {config.experimental_attention_variant=}."
     )
+    uses_sglang_backend = resolve_true_on_policy_runtime_policy(config).use_sglang_backend
 
     if use_transformer_engine:
         dense_layer_spec = get_gpt_layer_with_transformer_engine_spec(
@@ -564,6 +599,7 @@ def get_gpt_decoder_layer_specs(
             normalization=normalization,
             qk_l2_norm=qk_l2_norm,
             use_kitchen=config.use_kitchen,
+            use_true_on_policy_backend=uses_sglang_backend,
         )
         moe_layer_spec = get_gpt_layer_local_spec(
             num_experts=config.num_moe_experts,
@@ -574,6 +610,7 @@ def get_gpt_decoder_layer_specs(
             normalization=normalization,
             qk_l2_norm=qk_l2_norm,
             use_kitchen=config.use_kitchen,
+            use_true_on_policy_backend=uses_sglang_backend,
         )
 
     # Parse config.moe_layer_freq to determine the pattern of expert/dense layers.
@@ -642,8 +679,19 @@ def get_gpt_decoder_block_spec(
         local_layer_specs = layer_specs[offset : offset + num_layers_to_build]
 
     # Block spec.
-    if use_transformer_engine:
+    norm_type = (
+        normalization
+        if normalization is not None
+        else getattr(config, "normalization", "LayerNorm")
+    )
+
+    uses_sglang_backend = resolve_true_on_policy_runtime_policy(config).use_sglang_backend
+    if uses_sglang_backend and norm_type == "RMSNorm":
+        layer_norm_impl = SGLangFinalRMSNorm
+    elif use_transformer_engine:
         layer_norm_impl = TENorm
+    elif uses_sglang_backend:
+        layer_norm_impl = SGLangNorm
     else:
         layer_norm_impl = LNImpl
     block_spec = TransformerBlockSubmodules(
@@ -671,11 +719,14 @@ def get_gpt_mtp_block_spec(
         else:
             backend = TESpecProvider(fallback_to_eager_attn=config.fallback_to_eager_attn)
     else:
-        backend = (
-            KitchenSpecProvider(fallback=LocalSpecProvider())
-            if config.use_kitchen
-            else LocalSpecProvider()
-        )
+        if resolve_true_on_policy_runtime_policy(config).use_sglang_backend:
+            backend = SGLangSpecProvider()
+        else:
+            backend = (
+                KitchenSpecProvider(fallback=LocalSpecProvider())
+                if config.use_kitchen
+                else LocalSpecProvider()
+            )
     return get_gpt_mtp_block_spec_for_backend(
         config=config, spec=spec, backend=backend, vp_stage=vp_stage, pp_rank=pp_rank
     )

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import os
 from collections import OrderedDict
+from pathlib import Path
 from typing import Dict, Literal, Optional
 
 import torch
@@ -36,11 +38,73 @@ from megatron.core.transformer.multi_token_prediction import (
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
+from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
 from megatron.core.utils import (
     WrappedTensor,
     deprecate_inference_params,
     is_using_quantization_scales,
 )
+
+
+def apply_true_on_policy_logits_contract(
+    logits: Optional[Tensor], *, vocab_size: Optional[int] = None
+) -> Optional[Tensor]:
+    """Match SGLang's gathered-logits contract before log-softmax."""
+    if logits is None:
+        return None
+    if vocab_size is not None:
+        if logits.shape[-1] < vocab_size:
+            raise RuntimeError(
+                f"true_on_policy_vocab_size={vocab_size} exceeds gathered logits width "
+                f"{logits.shape[-1]}."
+            )
+        logits = logits[..., :vocab_size]
+    return logits
+
+
+_TOP_LM_HEAD_BWD_DUMP_COUNTER = 0
+
+
+def _maybe_dump_lm_head_backward(name: str, tensor: Optional[Tensor]) -> None:
+    dump_dir = os.environ.get("MILES_LM_HEAD_BACKWARD_DEBUG_DIR")
+    if not dump_dir or tensor is None or not tensor.requires_grad:
+        return
+
+    def hook(grad: Tensor) -> Tensor:
+        global _TOP_LM_HEAD_BWD_DUMP_COUNTER
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        finite_mask = torch.isfinite(grad)
+        finite = grad[finite_mask]
+        stats = {
+            "rank": rank,
+            "name": name,
+            "shape": tuple(grad.shape),
+            "dtype": str(grad.dtype),
+            "numel": grad.numel(),
+            "finite": finite_mask.sum().item(),
+            "nan": torch.isnan(grad).sum().item(),
+            "inf": torch.isinf(grad).sum().item(),
+        }
+        if finite.numel() > 0:
+            finite_f = finite.float()
+            stats.update(
+                {
+                    "max_abs_finite": finite_f.abs().max().item(),
+                    "min_finite": finite_f.min().item(),
+                    "max_finite": finite_f.max().item(),
+                }
+            )
+        else:
+            stats.update({"max_abs_finite": None, "min_finite": None, "max_finite": None})
+        counter = _TOP_LM_HEAD_BWD_DUMP_COUNTER
+        _TOP_LM_HEAD_BWD_DUMP_COUNTER += 1
+        path = Path(dump_dir) / f"rank_{rank}_{counter:05d}_{name}.pt"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({"stats": stats}, path)
+        print(f"[MILES_LM_HEAD_BACKWARD_DEBUG] {stats} wrote {path}", flush=True)
+        return grad
+
+    tensor.register_hook(hook)
 
 
 class GPTModel(LanguageModule):
@@ -564,6 +628,13 @@ class GPTModel(LanguageModule):
             mtp_kwargs=mtp_kwargs,
         )
 
+    def _apply_true_on_policy_logits_contract(self, logits: Optional[Tensor]) -> Optional[Tensor]:
+        if not resolve_true_on_policy_runtime_policy(self.config).apply_logits_contract:
+            return logits
+        return apply_true_on_policy_logits_contract(
+            logits, vocab_size=self.config.true_on_policy_vocab_size
+        )
+
     def _postprocess(
         self,
         hidden_states,
@@ -620,7 +691,13 @@ class GPTModel(LanguageModule):
         # Skip when mtp_num_layers is None or 0
         if self.config.mtp_num_layers and mtp_kwargs.get('mtp_labels', None) is not None:
             mtp_labels = mtp_kwargs['mtp_labels'].clone()
-            mtp_labels, _ = roll_tensor(mtp_labels, shifts=-1, dims=-1, cp_group=self.cp_group, packed_seq_params=packed_seq_params)
+            mtp_labels, _ = roll_tensor(
+                mtp_labels,
+                shifts=-1,
+                dims=-1,
+                cp_group=self.cp_group,
+                packed_seq_params=packed_seq_params,
+            )
 
             hidden_states_list = torch.chunk(hidden_states, 1 + self.config.mtp_num_layers, dim=0)
             hidden_states = hidden_states_list[0]
@@ -629,7 +706,13 @@ class GPTModel(LanguageModule):
                 loss_mask = torch.ones_like(mtp_labels)
             else:
                 # Otherwise, roll the loss_mask to keep up with the mtp_labels
-                loss_mask, _ = roll_tensor(loss_mask, shifts=-1, dims=-1, cp_group=self.cp_group, packed_seq_params=packed_seq_params)
+                loss_mask, _ = roll_tensor(
+                    loss_mask,
+                    shifts=-1,
+                    dims=-1,
+                    cp_group=self.cp_group,
+                    packed_seq_params=packed_seq_params,
+                )
             for mtp_layer_number in range(self.config.mtp_num_layers):
                 # Calc loss for the current Multi-Token Prediction (MTP) layers.
                 mtp_labels, _ = roll_tensor(
@@ -719,9 +802,12 @@ class GPTModel(LanguageModule):
                 ).unsqueeze(1)
 
         if has_config_logger_enabled(self.config) or labels is None:
+            _maybe_dump_lm_head_backward("lm_head_input_hidden_states", hidden_states)
             logits, _ = self.output_layer(
                 hidden_states, weight=output_weight, runtime_gather_output=runtime_gather_output
             )
+            logits = self._apply_true_on_policy_logits_contract(logits)
+            _maybe_dump_lm_head_backward("lm_head_output_logits", logits)
         else:
             logits = None
 
@@ -760,7 +846,10 @@ class GPTModel(LanguageModule):
                 **output_layer_kwargs,
             )
         else:
+            _maybe_dump_lm_head_backward("lm_head_input_hidden_states", hidden_states)
             logits, _ = self.output_layer(**output_layer_kwargs)
+            logits = self._apply_true_on_policy_logits_contract(logits)
+            _maybe_dump_lm_head_backward("lm_head_output_logits", logits)
             loss = self.compute_language_model_loss(labels, logits)
 
         return loss

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, Literal, Optional
 
 import torch
+import torch.utils.checkpoint
 from torch import Tensor
 
 from megatron.core import parallel_state, tensor_parallel
@@ -44,6 +45,52 @@ from megatron.core.utils import (
     deprecate_inference_params,
     is_using_quantization_scales,
 )
+
+
+# --- MTP total-variation (TV) distillation loss for the draft head -----------
+# Paper: "Breaking Entropy Bounds: Accelerating RL Training via MTP with
+# Rejection Sampling" (Bebop). Rejection-sampling accept_rate = 1 - d_TV(p, q),
+# so TV distance is the *direct* training target for the draft head (vs CE,
+# which only bounds it via Pinsker).
+#
+# Selected via TransformerConfig.mtp_loss_type ('ce' default | 'tv') and
+# TransformerConfig.mtp_tv_chunk (sequence-dim chunk for the vocab-sum, 0=off).
+#
+# TP=1 ONLY: with tensor-model-parallel size 1 the full vocab lives on each rank,
+# so softmax + sum_v min(p,q) over the last dim is exact (no vocab-parallel
+# all-reduce). A guard raises if TP>1.
+
+
+def _mtp_tv_per_token(draft_logits: Tensor, target_logits: Tensor, chunk: int = 0) -> Tensor:
+    """Per-position TV distance 1 - sum_v min(softmax(target), softmax(draft)).
+
+    Gradients flow through ``draft_logits`` (the MTP head); ``target_logits``
+    (the main model) must already be detached. Inputs are [s, b, V]; returns
+    [s, b]. Computed in fp32 for numerical stability.
+    """
+    def _overlap(d: Tensor, t: Tensor) -> Tensor:
+        q = torch.softmax(d.float(), dim=-1)
+        p = torch.softmax(t.float(), dim=-1)
+        return torch.minimum(p, q).sum(dim=-1)
+
+    if chunk and chunk > 0:
+        outs = []
+        for i in range(0, draft_logits.shape[0], chunk):
+            d_i = draft_logits[i : i + chunk]
+            t_i = target_logits[i : i + chunk]
+            # Gradient-checkpoint each chunk: keep only the per-token overlap [chunk] in the
+            # forward graph and recompute softmax(draft) in backward. Without this, every chunk's
+            # [chunk,V] softmax graph is retained until backward (~O(T*V) ≈ 12GiB @ T~12k), which
+            # OOMs joint training (full backbone) — chunking the forward alone does NOT fix backward
+            # retention. _overlap is deterministic (no RNG), so recompute is numerically exact.
+            if torch.is_grad_enabled() and d_i.requires_grad:
+                outs.append(torch.utils.checkpoint.checkpoint(_overlap, d_i, t_i, use_reentrant=False))
+            else:
+                outs.append(_overlap(d_i, t_i))
+        overlap = torch.cat(outs, dim=0)
+    else:
+        overlap = _overlap(draft_logits, target_logits)
+    return 1.0 - overlap
 
 
 def apply_true_on_policy_logits_contract(
@@ -734,7 +781,64 @@ class GPTModel(LanguageModule):
                 # Compute mtp loss without storing logits to save memory.
                 # Detach output layer params to prevent MTP gradient flowing
                 # to output layer (for RL training).
-                if self.fuse_linear_cross_entropy:
+                if self.config.mtp_loss_type == "tv":
+                    # --- TV distillation loss (Bebop) -------------------------
+                    # accept_rate = 1 - d_TV(p_main, q_draft); minimize d_TV.
+                    if parallel_state.get_tensor_model_parallel_world_size() != 1:
+                        raise NotImplementedError(
+                            "MTP_LOSS_TYPE=tv supports tensor-model-parallel size 1 "
+                            "only (full vocab per rank); got TP>1."
+                        )
+                    output_layer_params = {
+                        k: v.detach() for k, v in self.output_layer.named_parameters()
+                    }
+                    output_layer_buffers = dict(self.output_layer.named_buffers())
+                    # q: draft-head logits (grads flow through the MTP hidden states)
+                    mtp_logits, _ = torch.func.functional_call(
+                        self.output_layer,
+                        {**output_layer_params, **output_layer_buffers},
+                        (hidden_states_list[mtp_layer_number + 1],),
+                        {
+                            'weight': output_weight.detach() if output_weight is not None else None,
+                            'runtime_gather_output': runtime_gather_output,
+                        },
+                    )
+                    # p: main-model logits, fully detached. Align with mtp_labels
+                    # by left-rolling the main hidden states (k+1) steps along
+                    # seq (main predicts t+1; the k-th MTP target is t+k+2),
+                    # mirroring the roll_tensor label shifts above. Roll hidden
+                    # states (H) rather than logits (V) to save memory; the
+                    # zero-padded boundary position is masked by loss_mask.
+                    with torch.no_grad():
+                        # hidden states are [s, b, H] (seq-first). roll_tensor's
+                        # packed-sequence path requires the seq dim to be LAST
+                        # (it indexes tensor[..., cu_seqlens[i]:...]); the label
+                        # roll above works because labels are [b, s]. So move seq
+                        # to the last dim, roll (k+1) times to match mtp_labels'
+                        # (k+1) in-loop shifts, then move it back.
+                        main_hidden = hidden_states_list[0].movedim(0, -1)  # [b, H, s]
+                        for _ in range(mtp_layer_number + 1):
+                            main_hidden, _ = roll_tensor(
+                                main_hidden,
+                                shifts=-1,
+                                dims=-1,
+                                cp_group=self.cp_group,
+                                packed_seq_params=packed_seq_params,
+                            )
+                        main_hidden = main_hidden.movedim(-1, 0).contiguous()  # [s, b, H]
+                        main_logits, _ = torch.func.functional_call(
+                            self.output_layer,
+                            {**output_layer_params, **output_layer_buffers},
+                            (main_hidden,),
+                            {
+                                'weight': output_weight.detach() if output_weight is not None else None,
+                                'runtime_gather_output': runtime_gather_output,
+                            },
+                        )
+                    # per-token TV [s, b] -> [b, s] to match loss_mask / CE layout
+                    mtp_loss = _mtp_tv_per_token(mtp_logits, main_logits, chunk=self.config.mtp_tv_chunk)
+                    mtp_loss = mtp_loss.transpose(0, 1).contiguous()
+                elif self.fuse_linear_cross_entropy:
                     mtp_loss = self.output_layer(
                         output_cross_entropy_loss=self.fuse_linear_cross_entropy,
                         labels=mtp_labels,

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -604,6 +604,7 @@ class GPTModel(LanguageModule):
             packed_seq_params=packed_seq_params,
             sequence_len_offset=sequence_len_offset,
             padding_mask=padding_mask,
+            input_ids=input_ids,
             **(extra_block_kwargs or {}),
         )
 

--- a/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
+++ b/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
@@ -122,7 +122,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                     for param in _param_generator(optimizer):
                         gpu_param = self.cpu_copys_map_gpu_param[param]
                         gpu_param.data.copy_(param.data, non_blocking=True)
-                self._d2h_stream.record_event().wait(torch.cuda.current_stream())
+                self._h2d_stream.record_event().wait(torch.cuda.current_stream())
 
             return param_copy_back_gpu_hook
 
@@ -370,15 +370,24 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         if not self.param_update_in_fp32:
             return
         for param, v in self.state.items():
-            fp32_param = self.param_to_fp32_param[param]
-            fp32_param.data.copy_(v["master_param"])
+            inner_param = self.param_to_inner_param.get(param, param)
+            if inner_param is param:
+                continue
+            # Do the device/dtype conversion inside copy_ so the destination
+            # tensor owns the synchronization. Creating an intermediate
+            # non_blocking CPU tensor can race with the following CPU copy.
+            inner_param.data.copy_(v["master_param"].detach(), non_blocking=False)
 
     def update_fp32_param_by_new_param(self):
         """
-        Update the fp32 parameters by the new parameters.
+        Refresh optimizer-side parameter copies after model weights are loaded
+        or otherwise changed outside the optimizer.
         """
-        for param, fp32_param in self.param_to_fp32_param.items():
-            fp32_param.data.copy_(param)
+        for param, inner_param in self.param_to_inner_param.items():
+            if inner_param is param:
+                continue
+            # Blocking direct D2H copy is required here. 
+            inner_param.data.copy_(param.detach(), non_blocking=False)
 
     def _register_load_state_dict_hooks(self):
         def pre_load_state_dict_hook(self, state_dict):

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1795,7 +1795,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     bucket_state = [
                         bucket_state_elem
                         for bucket_state_elem in bucket_state
-                        if not bucket_state_elem['padding']
+                        if not bucket_state_elem.get('padding', False)
                     ]
 
                     assert len(bucket_state) == len(gbuf_range_map["param_map"]), (

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -686,6 +686,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 # TE FusedAdam will not accumulate step for empty param groups, so we need to
                 # align the step across param groups.
                 param_group["step"] = int(step)
+            if "step" in param_group and param_group["step"] is None:
+                del param_group["step"]
 
         # Grad scaler state.
         if self.grad_scaler:
@@ -1666,6 +1668,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         for key in tensors:
                             if key == 'padding':
                                 tensors[key] = LocalNonpersistentObject(tensors[key])
+                                continue
+                            if key == 'step':
                                 continue
                             assert tensors[key].shape == (gbuf_local_end - gbuf_local_start,), (
                                 tensors[key].shape,

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -422,7 +422,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                 # fp32 params.
                 elif model_param.type() == 'torch.cuda.FloatTensor':
-                    shard_model_param = model_param.view(-1)[param_range.start : param_range.end]
+                    # Keep shard tensors as leaf tensors for torch Optimizer.
+                    shard_model_param = model_param.detach().view(-1)[param_range.start : param_range.end]
                     model_fp32_params_this_group.append(model_param)
                     shard_fp32_params_this_group.append(shard_model_param)
                     tensor_parallel.copy_tensor_model_parallel_attributes(

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -335,8 +335,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         shard_fp32_groups = []
         shard_fp32_from_float16_groups = []
 
+        model_param_group_index_map = {}
+
         # Allocate (or slice) each group's param shard.
-        for group_range in opt_group_ranges:
+        for group_index, group_range in enumerate(opt_group_ranges):
 
             # Params of this group.
             model_float16_params_this_group = []
@@ -449,12 +451,24 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     *shard_float16_params_this_group,
                 ]
 
+            # Build correct order for later access in models with mixed precision params.
+            # When a model has both fp32 and bf16/fp16 parameters (e.g., some params kept
+            # in fp32 via _keep_fp32), the parameter ordering in optimizer groups may differ
+            # from _build_optimizer_group_ranges. This rebuilds the index map to match the
+            # actual order used by the optimizer after shard allocation.
+            for new_order, model_param in enumerate(model_fp32_params_this_group):
+                model_param_group_index_map[model_param] = (group_index, new_order)
+            offset = len(model_fp32_params_this_group)
+            for i, model_param in enumerate(model_float16_params_this_group):
+                model_param_group_index_map[model_param] = (group_index, offset + i)
+
         return (
             model_float16_groups,
             model_fp32_groups,
             shard_float16_groups,
             shard_fp32_groups,
             shard_fp32_from_float16_groups,
+            model_param_group_index_map,
         )
 
     def __init__(
@@ -587,7 +601,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         param.main_param_sharded = True
 
         # Optimizer ranges.
-        (self.model_param_group_index_map, self.opt_group_ranges) = (
+        (_, self.opt_group_ranges) = (
             self._build_optimizer_group_ranges(self.optimizer.param_groups, self.gbuf_ranges)
         )
 
@@ -598,6 +612,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             self.shard_float16_groups,
             self.shard_fp32_groups,
             self.shard_fp32_from_float16_groups,
+            self.model_param_group_index_map,
         ) = self._build_model_and_main_param_groups(
             self.gbuf_ranges, self.model_param_gbuf_map, self.opt_group_ranges, config
         )

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -56,6 +56,7 @@ from .cpu_offloading.optimizer_state_offloader import OptimizerStateOffloader
 from .grad_scaler import MegatronGradScaler
 from .optimizer import MixedPrecisionOptimizer, _zero_grad_group_helper, param_group_identifier_keys
 from .optimizer_config import OptimizerConfig
+from .fused_adam_patch import apply_fused_adam_patch, is_patch_applied
 
 logger = getLogger(__name__)
 
@@ -810,8 +811,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                             # Allocate dummy tensors.
                             numel = len(param_range_map["gbuf_world"])
-                            init_shard = lambda dtype=torch.float32: torch.empty(
-                                (numel,), dtype=dtype, device=torch.cuda.current_device()
+                            low_mem_resume = self.config.low_memory_resume
+                            if low_mem_resume and USING_TE_OPTIMIZER and not is_patch_applied():
+                                apply_fused_adam_patch()
+                            init_device = 'cpu' if low_mem_resume else torch.cuda.current_device()
+                            init_shard = lambda dtype=torch.float32, _device=init_device: torch.empty(
+                                (numel,), dtype=dtype, device=_device
                             )
 
                             # For precision_aware_optimizer, the empty tensors should also be
@@ -902,6 +907,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 self.load_parameter_state_from_fs_model_space(param_state)
             else:
                 raise NotImplementedError(f'Unknown sharding_type: {sharding_type}')
+
+            if self.config.low_memory_resume:
+                for state in self.optimizer.state.values():
+                    for k, v in state.items():
+                        if isinstance(v, torch.Tensor) and v.device.type == 'cpu':
+                            state[k] = v.to(torch.cuda.current_device())
 
     def _get_main_param_and_optimizer_states(self, model_param):
         """Return a dict containing the main param and optimizer states corresponding to the input

--- a/megatron/core/optimizer/fused_adam_patch.py
+++ b/megatron/core/optimizer/fused_adam_patch.py
@@ -1,0 +1,66 @@
+"""Monkey-patch for TransformerEngine FusedAdam to support CPU allocation
+during low-memory checkpoint resume (--low-memory-resume).
+
+This prevents GPU OOM during checkpoint loading by initially allocating
+optimizer states (exp_avg, exp_avg_sq) on CPU, then moving them to GPU
+after the checkpoint is fully loaded.
+
+The patch is only applied when low_memory_resume is enabled, so
+_patched_initialize_state unconditionally allocates on CPU.
+"""
+
+import torch
+from logging import getLogger
+
+logger = getLogger(__name__)
+_patch_applied = False
+
+
+def _patched_initialize_state(self, param, state_name, zero_buffer, store_param_remainders=False):
+    """Patched _initialize_state: allocate on CPU for low-memory resume."""
+    from transformer_engine.pytorch.tensor.float8_tensor import Float8Quantizer
+    from transformer_engine.pytorch.quantized_tensor import QuantizedTensor
+    import transformer_engine_torch as tex
+
+    dtype = self.name_to_dtype_map[state_name]
+    param_for_empty = param.dequantize() if isinstance(param, QuantizedTensor) else param
+
+    device = torch.device('cpu')
+
+    if store_param_remainders:
+        data = torch.zeros(param_for_empty.shape, dtype=torch.int16, device=device)
+    else:
+        data = torch.empty(param_for_empty.shape, dtype=dtype, device=device)
+
+    if zero_buffer:
+        data.zero_()
+
+    if dtype == torch.uint8:
+        quantizer = Float8Quantizer(
+            scale=torch.ones([1], dtype=torch.float32, device=device),
+            amax=torch.zeros([1], dtype=torch.float32, device=device),
+            fp8_dtype=tex.DType.kFloat8E4M3,
+        )
+        self.state[param][state_name] = quantizer.make_empty(param.shape)
+        self.state[param][state_name].quantize_(data.float())
+    else:
+        self.state[param][state_name] = data
+
+    if dtype != torch.float32:
+        if param not in self._scales:
+            self._scales[param] = {}
+        self._scales[param][state_name] = torch.ones([1], dtype=torch.float32, device=device)
+
+
+def apply_fused_adam_patch():
+    global _patch_applied
+    if _patch_applied:
+        return
+
+    from transformer_engine.pytorch.optimizers import FusedAdam
+    FusedAdam._initialize_state = _patched_initialize_state
+    _patch_applied = True
+
+
+def is_patch_applied():
+    return _patch_applied

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -330,6 +330,9 @@ class OptimizerConfig:
     reload them before the next optimizer step.
     """
 
+    low_memory_resume: bool = False
+    """If True, allocate optimizer states on CPU during checkpoint loading to prevent GPU OOM."""
+
     ################
     # Miscellaneous
     ################

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -11,6 +11,7 @@ from typing import Callable, List, Optional
 
 import numpy as np
 import torch
+import torch.distributed as dist
 
 from .utils import GlobalMemoryBuffer, GlobalSymmetricMemoryBuffer, is_torch_min_version
 

--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -26,22 +26,22 @@ def _batched_p2p_ops(
     ops = []
     if tensor_send_prev is not None:
         send_prev_op = torch.distributed.P2POp(
-            torch.distributed.isend, tensor_send_prev, prev_pipeline_rank, group
+            torch.distributed.isend, tensor_send_prev, prev_pipeline_rank,
         )
         ops.append(send_prev_op)
     if tensor_recv_prev is not None:
         recv_prev_op = torch.distributed.P2POp(
-            torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank, group
+            torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank,
         )
         ops.append(recv_prev_op)
     if tensor_send_next is not None:
         send_next_op = torch.distributed.P2POp(
-            torch.distributed.isend, tensor_send_next, next_pipeline_rank, group
+            torch.distributed.isend, tensor_send_next, next_pipeline_rank,
         )
         ops.append(send_next_op)
     if tensor_recv_next is not None:
         recv_next_op = torch.distributed.P2POp(
-            torch.distributed.irecv, tensor_recv_next, next_pipeline_rank, group
+            torch.distributed.irecv, tensor_recv_next, next_pipeline_rank,
         )
         ops.append(recv_next_op)
     if len(ops) > 0:

--- a/megatron/core/pipeline_parallel/p2p_communication.py
+++ b/megatron/core/pipeline_parallel/p2p_communication.py
@@ -181,17 +181,18 @@ class P2PCommunicator:
             (recv_prev_shape, recv_next_shape)
         """
         config = self.config
+        num_dims = 4 if config.dsv4_mode else 3
         recv_prev_shape_tensor = None
         recv_next_shape_tensor = None
         send_prev_shape_tensor = None
         send_next_shape_tensor = None
         if recv_prev:
             recv_prev_shape_tensor = torch.empty(
-                (3,), device=torch.cuda.current_device(), dtype=torch.int64
+                (num_dims,), device=torch.cuda.current_device(), dtype=torch.int64
             )
         if recv_next:
             recv_next_shape_tensor = torch.empty(
-                (3,), device=torch.cuda.current_device(), dtype=torch.int64
+                (num_dims,), device=torch.cuda.current_device(), dtype=torch.int64
             )
         if tensor_send_prev is not None:
             send_prev_shape_tensor = torch.tensor(
@@ -241,11 +242,11 @@ class P2PCommunicator:
             # should take this out once the bug with batch_isend_irecv is resolved.
             torch.cuda.synchronize()
 
-        recv_prev_shape = [0, 0, 0]
+        recv_prev_shape = [0] * num_dims
         if recv_prev_shape_tensor is not None:
             recv_prev_shape = recv_prev_shape_tensor.tolist()
 
-        recv_next_shape = [0, 0, 0]
+        recv_next_shape = [0] * num_dims
         if recv_next_shape_tensor is not None:
             recv_next_shape = recv_next_shape_tensor.tolist()
 

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -1149,7 +1149,10 @@ def forward_backward_pipelining_with_interleaving(
 
     model_type = get_model_type(model[0])
 
-    tensor_shape = [seq_length, micro_batch_size, config.hidden_size]
+    if config.dsv4_mode:
+        tensor_shape = [seq_length, micro_batch_size, config.dsv4_hc_mult, config.hidden_size]
+    else:
+        tensor_shape = [seq_length, micro_batch_size, config.hidden_size]
     tensor_shape[0] = tensor_shape[0] // cp_group.size()
     if config.sequence_parallel:
         tensor_shape[0] = tensor_shape[0] // tp_group.size()
@@ -2098,7 +2101,10 @@ def get_tensor_shapes(
     if config.sequence_parallel:
         effective_seq_length = effective_seq_length // tp_group.size()
 
-    tensor_shapes.append((effective_seq_length, micro_batch_size, config.hidden_size))
+    if config.dsv4_mode:
+        tensor_shapes.append((effective_seq_length, micro_batch_size, config.dsv4_hc_mult, config.hidden_size))
+    else:
+        tensor_shapes.append((effective_seq_length, micro_batch_size, config.hidden_size))
     return tensor_shapes
 
 

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -30,6 +30,7 @@ from megatron.core.utils import (
 
 from ..dist_checkpointing.mapping import ShardedStateDict
 from ..transformer.utils import make_sharded_tensors_for_checkpoint
+from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
 from .mappings import (
     copy_to_tensor_model_parallel_region,
     gather_from_sequence_parallel_region,
@@ -346,21 +347,31 @@ class LinearWithFrozenWeight(torch.autograd.Function):
         ctx.save_for_backward(weight)
         ctx.allreduce_dgrad = allreduce_dgrad
         ctx.tp_group = tp_group
-        output = torch.matmul(input, weight.t())
-        if bias is not None:
-            output = output + bias
-        return output
+        return _linear_forward_with_optional_batch_invariant_matmul(input, weight, bias)
 
     @staticmethod
     @custom_bwd
     def backward(ctx, grad_output):
         """Backward with frozen weight."""
         (weight,) = ctx.saved_tensors
-        grad_input = grad_output.matmul(weight)
+        grad_input = _linear_dgrad_matmul(grad_output, weight)
+        _maybe_dump_linear_backward_debug(
+            tag="pre_comm",
+            grad_input=grad_input,
+            grad_output=grad_output,
+            weight=weight,
+            allreduce_dgrad=ctx.allreduce_dgrad,
+            sequence_parallel=False,
+        )
 
         if ctx.allreduce_dgrad:
             # All-reduce. Note: here async and sync are effectively the same.
-            torch.distributed.all_reduce(grad_input, group=ctx.tp_group)
+            if _should_allreduce_dgrad_in_fp32(grad_input):
+                grad_input_fp32 = grad_input.float()
+                torch.distributed.all_reduce(grad_input_fp32, group=ctx.tp_group)
+                grad_input = grad_input_fp32.to(grad_input.dtype)
+            else:
+                torch.distributed.all_reduce(grad_input, group=ctx.tp_group)
 
         return grad_input, None, None, None, None
 
@@ -448,6 +459,113 @@ def linear_with_frozen_weight(
     return LinearWithFrozenWeight.apply(*args)
 
 
+def _linear_forward_with_optional_batch_invariant_matmul(
+    input: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor]
+) -> torch.Tensor:
+    if input.is_cuda:
+        from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+            is_batch_invariant_mode_enabled,
+            matmul_persistent,
+        )
+
+        if is_batch_invariant_mode_enabled():
+            input_shape = input.shape
+            input_2d = input.reshape(-1, input_shape[-1])
+            output_2d = matmul_persistent(input_2d, weight.t(), bias)
+            return output_2d.reshape(*input_shape[:-1], weight.shape[0])
+
+    output = torch.matmul(input, weight.t())
+    if bias is not None:
+        output = output + bias
+    return output
+
+
+def _maybe_dump_linear_backward_debug(
+    *,
+    tag: str,
+    grad_input: torch.Tensor,
+    grad_output: torch.Tensor,
+    weight: torch.Tensor,
+    allreduce_dgrad: bool,
+    sequence_parallel: bool,
+) -> None:
+    debug_dir = os.environ.get("MILES_LINEAR_BACKWARD_DEBUG_DIR")
+    if not debug_dir or torch.isfinite(grad_input).all().item():
+        return
+
+    max_dumps = int(os.environ.get("MILES_LINEAR_BACKWARD_DEBUG_MAX_FILES", "256"))
+    counter = getattr(_maybe_dump_linear_backward_debug, "_counter", 0)
+    if counter >= max_dumps:
+        return
+    _maybe_dump_linear_backward_debug._counter = counter + 1
+
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        rank = torch.distributed.get_rank()
+    else:
+        rank = -1
+
+    def _stats(tensor: torch.Tensor):
+        flat = tensor.detach().view(-1)
+        finite = torch.isfinite(flat)
+        stats = {
+            "shape": tuple(tensor.shape),
+            "dtype": str(tensor.dtype),
+            "numel": flat.numel(),
+            "finite": int(finite.sum().item()),
+            "nan": int(torch.isnan(flat).sum().item()),
+            "inf": int(torch.isinf(flat).sum().item()),
+        }
+        if stats["finite"] > 0:
+            finite_values = flat[finite].float()
+            stats.update(
+                {
+                    "max_abs_finite": float(finite_values.abs().max().item()),
+                    "min_finite": float(finite_values.min().item()),
+                    "max_finite": float(finite_values.max().item()),
+                }
+            )
+        return stats
+
+    os.makedirs(debug_dir, exist_ok=True)
+    shape_tag = "x".join(str(dim) for dim in weight.shape)
+    path = os.path.join(
+        debug_dir, f"rank_{rank}_call_{counter:05d}_{tag}_weight_{shape_tag}_pid_{os.getpid()}.pt"
+    )
+    torch.save(
+        {
+            "rank": rank,
+            "tag": tag,
+            "allreduce_dgrad": allreduce_dgrad,
+            "sequence_parallel": sequence_parallel,
+            "grad_input": _stats(grad_input),
+            "grad_output": _stats(grad_output),
+            "weight": _stats(weight),
+        },
+        path,
+    )
+    print(f"[MILES_LINEAR_BACKWARD_DEBUG] wrote {path}", flush=True)
+
+
+def _should_allreduce_dgrad_in_fp32(grad_input: torch.Tensor) -> bool:
+    return os.environ.get(
+        "MEGATRON_TRUE_ON_POLICY_DGRAD_ALLREDUCE_FP32"
+    ) == "1" and grad_input.dtype in (torch.float16, torch.bfloat16)
+
+
+def _should_compute_dgrad_in_fp32(grad_output: torch.Tensor, weight: torch.Tensor) -> bool:
+    return (
+        os.environ.get("MEGATRON_TRUE_ON_POLICY_LINEAR_DGRAD_FP32") == "1"
+        and grad_output.dtype in (torch.float16, torch.bfloat16)
+        and weight.dtype in (torch.float16, torch.bfloat16)
+    )
+
+
+def _linear_dgrad_matmul(grad_output: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    if _should_compute_dgrad_in_fp32(grad_output, weight):
+        return grad_output.float().matmul(weight.float())
+    return grad_output.matmul(weight)
+
+
 class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
     """See linear_with_grad_accumulation_and_async_allreduce"""
 
@@ -493,10 +611,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
         else:
             total_input = input
 
-        output = torch.matmul(total_input, weight.t())
-        if bias is not None:
-            output = output + bias
-        return output
+        return _linear_forward_with_optional_batch_invariant_matmul(total_input, weight, bias)
 
     @staticmethod
     @custom_bwd
@@ -536,7 +651,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
                 total_input = all_gather_buffer
             else:
                 total_input = input
-        grad_input = grad_output.matmul(weight)
+        grad_input = _linear_dgrad_matmul(grad_output, weight)
 
         if ctx.sequence_parallel and wgrad_compute:
             # pylint: disable=possibly-used-before-assignment
@@ -549,7 +664,9 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
 
         if ctx.allreduce_dgrad:
             # Asynchronous all-reduce
-            handle = torch.distributed.all_reduce(grad_input, group=tp_group, async_op=True)
+            dgrad_allreduce_fp32 = _should_allreduce_dgrad_in_fp32(grad_input)
+            grad_input_comm = grad_input.float() if dgrad_allreduce_fp32 else grad_input
+            handle = torch.distributed.all_reduce(grad_input_comm, group=tp_group, async_op=True)
             # Here we rely on CUDA_DEVICE_MAX_CONNECTIONS=1 to ensure that the
             # all-reduce is scheduled before the weight gradient computation
 
@@ -630,6 +747,16 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
 
         if ctx.allreduce_dgrad:
             handle.wait()
+            if dgrad_allreduce_fp32:
+                grad_input = grad_input_comm.to(grad_input.dtype)
+            _maybe_dump_linear_backward_debug(
+                tag="post_allreduce",
+                grad_input=grad_input,
+                grad_output=grad_output,
+                weight=weight,
+                allreduce_dgrad=ctx.allreduce_dgrad,
+                sequence_parallel=ctx.sequence_parallel,
+            )
 
         return grad_input, grad_weight, grad_bias, None, None, None, None, None, None
 
@@ -804,6 +931,8 @@ class ColumnParallelLinear(torch.nn.Module):
             will be disabled. Defaults to False. This feature is used by Lora Adapter in Nemo to
             delay and fuse reduction along with other gradients for performance optimization.
     """
+
+    backend_name = "local"
 
     def __init__(
         self,
@@ -1137,6 +1266,8 @@ class RowParallelLinear(torch.nn.Module):
 
     """
 
+    backend_name = "local"
+
     def __init__(
         self,
         input_size: int,
@@ -1315,7 +1446,13 @@ class RowParallelLinear(torch.nn.Module):
                 output_parallel, group=self.tp_group
             )
         else:
-            output_ = reduce_from_tensor_model_parallel_region(output_parallel, group=self.tp_group)
+            output_ = reduce_from_tensor_model_parallel_region(
+                output_parallel,
+                group=self.tp_group,
+                deterministic=resolve_true_on_policy_runtime_policy(
+                    self.config
+                ).deterministic_row_parallel_reduce,
+            )
         if not self.skip_bias_add:
             output = (output_ + self.bias) if self.bias is not None else output_
             output_bias = None

--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -33,6 +33,43 @@ def _reduce(input_, group):
     return input_
 
 
+def _is_power_of_two(value: int) -> bool:
+    return value > 0 and (value & (value - 1)) == 0
+
+
+def _tree_reduce_sum_from_gathered(gathered):
+    """Reduce gathered TP partials with a fixed pairwise tree order."""
+    partials = list(torch.unbind(gathered, dim=0))
+
+    while len(partials) > 1:
+        next_partials = []
+        for index in range(0, len(partials), 2):
+            next_partials.append(partials[index] + partials[index + 1])
+        partials = next_partials
+
+    return partials[0]
+
+
+def _tree_all_reduce_sum(input_, group):
+    """Deterministic TP sum via all-gather plus fixed local tree reduction."""
+    assert group is not None, "group should not be None"
+
+    world_size = group.size()
+    if world_size == 1:
+        return input_
+    if not _is_power_of_two(world_size):
+        raise RuntimeError(
+            "Deterministic TP tree reduction currently requires a power-of-two "
+            f"tensor parallel size, but got {world_size}."
+        )
+
+    gathered_shape = [input_.shape[0] * world_size, *input_.shape[1:]]
+    gathered = torch.empty(gathered_shape, dtype=input_.dtype, device=input_.device)
+    dist_all_gather_func(gathered, input_.contiguous(), group=group)
+    gathered = gathered.view(world_size, *input_.shape)
+    return _tree_reduce_sum_from_gathered(gathered)
+
+
 def _split_along_last_dim(input_, group):
     """Split the tensor along its last dimension and keep the
     corresponding slice."""
@@ -226,6 +263,25 @@ class _ReduceFromModelParallelRegion(torch.autograd.Function):
     def forward(ctx, input_, group):
         """Forward function."""
         return _reduce(input_, group)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Backward function."""
+        return grad_output, None
+
+
+class _DeterministicReduceFromModelParallelRegion(torch.autograd.Function):
+    """Deterministic TP reduction using a fixed tree-sum order."""
+
+    @staticmethod
+    def symbolic(graph, input_, group):
+        """Symbolic function for tracing."""
+        return _tree_all_reduce_sum(input_, group)
+
+    @staticmethod
+    def forward(ctx, input_, group):
+        """Forward function."""
+        return _tree_all_reduce_sum(input_, group)
 
     @staticmethod
     def backward(ctx, grad_output):
@@ -472,9 +528,11 @@ def copy_to_tensor_model_parallel_region(input_, group=None):
     return _CopyToModelParallelRegion.apply(input_, group)
 
 
-def reduce_from_tensor_model_parallel_region(input_, group=None):
+def reduce_from_tensor_model_parallel_region(input_, group=None, deterministic=False):
     """Wrapper for autograd function: forward: all reduce, backward copy"""
     group = get_tensor_model_parallel_group_if_none(group)
+    if deterministic:
+        return _DeterministicReduceFromModelParallelRegion.apply(input_, group)
     return _ReduceFromModelParallelRegion.apply(input_, group)
 
 

--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -19,8 +19,14 @@ except:
     dist_reduce_scatter_func = torch.distributed._reduce_scatter_base
 
 
-def _reduce(input_, group):
-    """All-reduce the input tensor across model parallel group."""
+def _reduce(input_, group, fp32=False):
+    """All-reduce the input tensor across model parallel group.
+
+    Args:
+        input_: Input tensor.
+        group: Process group for all-reduce.
+        fp32: If True, cast to FP32 before all-reduce, then cast back.
+    """
     assert group is not None, "group should not be None"
 
     # Bypass the function if we are using only 1 GPU.
@@ -28,7 +34,13 @@ def _reduce(input_, group):
         return input_
 
     # All-reduce.
-    torch.distributed.all_reduce(input_.contiguous(), group=group)
+    if fp32:
+        orig_dtype = input_.dtype
+        input_fp32 = input_.float().contiguous()
+        torch.distributed.all_reduce(input_fp32, group=group)
+        input_.copy_(input_fp32.to(orig_dtype))
+    else:
+        torch.distributed.all_reduce(input_.contiguous(), group=group)
 
     return input_
 
@@ -231,24 +243,56 @@ def _reduce_scatter_along_first_dim(input_, group, input_split_sizes=None, use_g
     return output
 
 
+def split_along_nth_dim(input_, dim, group):
+    """Split the tensor along the specified dimension and keep the
+    corresponding slice. This is a pure function without autograd.
+
+    Args:
+        input_: Input tensor to split.
+        dim: The dimension along which to split.
+        group: The process group for splitting.
+
+    Returns:
+        The slice of the input tensor corresponding to the current rank.
+    """
+    assert group is not None, "group should not be None"
+
+    world_size = group.size()
+    if world_size == 1:
+        return input_
+
+    dim_size = input_.size(dim)
+    assert (
+        dim_size % world_size == 0
+    ), f"Dimension {dim} of the tensor (size {dim_size}) should be divisible by world size {world_size}"
+    local_dim_size = dim_size // world_size
+    rank = group.rank()
+    dim_offset = rank * local_dim_size
+
+    output = input_.narrow(dim, dim_offset, local_dim_size).contiguous()
+
+    return output
+
+
 class _CopyToModelParallelRegion(torch.autograd.Function):
     """Pass the input to the model parallel region."""
 
     @staticmethod
-    def symbolic(graph, input_, group):
+    def symbolic(graph, input_, group, all_reduce_grad_fp32):
         """Symbolic function for tracing."""
         return input_
 
     @staticmethod
-    def forward(ctx, input_, group):
+    def forward(ctx, input_, group, all_reduce_grad_fp32):
         """Forward function."""
         ctx.group = group
+        ctx.all_reduce_grad_fp32 = all_reduce_grad_fp32
         return input_
 
     @staticmethod
     def backward(ctx, grad_output):
         """Backward function."""
-        return _reduce(grad_output, ctx.group), None
+        return _reduce(grad_output, ctx.group, fp32=ctx.all_reduce_grad_fp32), None, None
 
 
 class _ReduceFromModelParallelRegion(torch.autograd.Function):
@@ -522,10 +566,16 @@ class _AllToAll(torch.autograd.Function):
 # -----------------
 
 
-def copy_to_tensor_model_parallel_region(input_, group=None):
-    """Wrapper for autograd function: forward: copy, backward allreduce"""
+def copy_to_tensor_model_parallel_region(input_, group=None, all_reduce_grad_fp32=False):
+    """Wrapper for autograd function: forward: copy, backward allreduce
+
+    Args:
+        input_: Input tensor.
+        group: Process group for all-reduce. If None, uses default TP group.
+        all_reduce_grad_fp32: If True, cast gradients to FP32 before all-reduce, then cast back.
+    """
     group = get_tensor_model_parallel_group_if_none(group)
-    return _CopyToModelParallelRegion.apply(input_, group)
+    return _CopyToModelParallelRegion.apply(input_, group, all_reduce_grad_fp32)
 
 
 def reduce_from_tensor_model_parallel_region(input_, group=None, deterministic=False):

--- a/megatron/core/tensor_parallel/matmul_tp_inv.py
+++ b/megatron/core/tensor_parallel/matmul_tp_inv.py
@@ -1,0 +1,6 @@
+"""Compatibility imports for true-on-policy TP-invariant matmul helpers.
+
+New code should import from :mod:`miles_megatron_plugins.true_on_policy.matmul`.
+"""
+
+from miles_megatron_plugins.true_on_policy.matmul import *  # noqa: F403

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1491,6 +1491,16 @@ class SelfAttention(Attention):
         if output_gate:
             # Gate [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
             gate = gate.reshape(*gate.shape[:2], -1, self.hidden_size_per_attention_head)
+            if self.config.num_query_groups < self.world_size:
+                # gate has the same head layout as query before slicing.
+                # Apply the same TP slice so gate matches the per-rank query.
+                idx = get_tensor_model_parallel_rank() % (
+                    self.world_size // self.config.num_query_groups
+                )
+                size = self.num_attention_heads_per_partition // (
+                    self.world_size // self.config.num_query_groups
+                )
+                gate = gate[:, :, idx * size : (idx + 1) * size, :]
             return query, key, value, gate
 
         return query, key, value

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import copy
 import inspect
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Optional, Protocol, Tuple, Union
@@ -17,6 +18,18 @@ from megatron.core.models.common.embeddings.rope_utils import (
     apply_rotary_pos_emb,
     apply_rotary_pos_emb_with_cos_sin,
 )
+
+try:
+    from miles_megatron_plugins.true_on_policy.sglang_backend import (
+        is_sglang_rope_enabled,
+        sglang_apply_rotary_pos_emb_with_freqs,
+    )
+
+    HAVE_SGLANG_ROPE = True
+except ImportError:
+    HAVE_SGLANG_ROPE = False
+    is_sglang_rope_enabled = lambda: False
+    sglang_apply_rotary_pos_emb_with_freqs = None
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.parallel_state import (
     get_data_parallel_group,
@@ -34,6 +47,7 @@ from megatron.core.tensor_parallel.mappings import all_gather_last_dim_from_tens
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
+from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
 from megatron.core.typed_torch import apply_module, not_none
 from megatron.core.utils import (
     deprecate_inference_params,
@@ -115,6 +129,67 @@ try:
     HAVE_FUSED_QKV_ROPE = True
 except ImportError:
     HAVE_FUSED_QKV_ROPE = False
+
+
+def _register_attention_grad_debug(tensor: Tensor, *, layer_number: int, name: str) -> None:
+    debug_dir = os.environ.get("MILES_ACTIVATION_GRAD_DEBUG_DIR")
+    if not debug_dir or not torch.is_tensor(tensor) or not tensor.requires_grad:
+        return
+
+    debug_key = f"attention:{layer_number}:{name}"
+
+    def _hook(grad: Tensor) -> Tensor:
+        if torch.isfinite(grad).all().item():
+            return grad
+
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else -1
+        seen = getattr(_register_attention_grad_debug, "_seen", set())
+        seen_key = (rank, debug_key)
+        if seen_key in seen:
+            return grad
+        seen.add(seen_key)
+        _register_attention_grad_debug._seen = seen
+
+        flat = grad.detach().view(-1)
+        finite = torch.isfinite(flat)
+        stats = {
+            "rank": rank,
+            "layer_number": layer_number,
+            "module": "attention",
+            "name": name,
+            "shape": tuple(grad.shape),
+            "dtype": str(grad.dtype),
+            "numel": flat.numel(),
+            "finite": int(finite.sum().item()),
+            "nan": int(torch.isnan(flat).sum().item()),
+            "inf": int(torch.isinf(flat).sum().item()),
+        }
+        if stats["finite"] > 0:
+            finite_values = flat[finite].float()
+            stats.update(
+                {
+                    "max_abs_finite": float(finite_values.abs().max().item()),
+                    "min_finite": float(finite_values.min().item()),
+                    "max_finite": float(finite_values.max().item()),
+                }
+            )
+
+        os.makedirs(debug_dir, exist_ok=True)
+        path = os.path.join(
+            debug_dir, f"rank_{rank}_layer_{layer_number}_attention_{name}_pid_{os.getpid()}.pt"
+        )
+        torch.save(stats, path)
+        print(f"[MILES_ACTIVATION_GRAD_DEBUG] {stats} wrote {path}", flush=True)
+        return grad
+
+    tensor.register_hook(_hook)
+
+
+def _sglang_cast_dense_tensor_math_input(tensor: Tensor) -> Tensor:
+    """Match SGLang true-on-policy dense tensor math dtype boundaries."""
+    if tensor.dtype == torch.bfloat16:
+        return tensor
+    return tensor.to(torch.bfloat16)
 
 
 class LinearQkv(Protocol):
@@ -221,6 +296,13 @@ class SelfAttentionSubmodules:
     linear_proj: Union[ModuleSpec, type] = None
     q_layernorm: Union[ModuleSpec, type] = None
     k_layernorm: Union[ModuleSpec, type] = None
+
+
+def _is_ulysses_cp(config: TransformerConfig) -> bool:
+    cp_comm_type = getattr(config, "cp_comm_type", None)
+    if isinstance(cp_comm_type, list):
+        cp_comm_type = cp_comm_type[0] if cp_comm_type else None
+    return config.context_parallel_size > 1 and cp_comm_type == "a2a"
 
 
 @dataclass
@@ -1095,30 +1177,58 @@ class Attention(MegatronModule, ABC):
                 cu_seqlens_q = cu_seqlens_kv = None
 
             if split_qkv:
+                ulysses_cp = _is_ulysses_cp(self.config)
                 if q_pos_emb is not None:
-                    # TODO VIJAY: simplify
-                    if inference_context is None or inference_context.is_static_batching():
-                        query = apply_rotary_pos_emb(
-                            query,
-                            q_pos_emb,
+                    use_sglang_rope = (
+                        HAVE_SGLANG_ROPE and is_sglang_rope_enabled() and packed_seq_params is None
+                    )
+                    sglang_rope_applied = False
+                    if use_sglang_rope and sglang_apply_rotary_pos_emb_with_freqs is not None:
+                        q_freqs, _ = (
+                            q_pos_emb if isinstance(q_pos_emb, tuple) else (q_pos_emb, q_pos_emb)
+                        )
+                        query = sglang_apply_rotary_pos_emb_with_freqs(
+                            query, q_freqs, self.config, layer_number=self.layer_number
+                        )
+                        sglang_rope_applied = True
+                    if not sglang_rope_applied:
+                        if inference_context is None or inference_context.is_static_batching():
+                            query = apply_rotary_pos_emb(
+                                query,
+                                q_pos_emb,
+                                config=self.config,
+                                cu_seqlens=cu_seqlens_q,
+                                mscale=_yarn_get_concentration_factor_from_config(self.config),
+                                cp_group=self.pg_collection.cp,
+                                ulysses_cp=ulysses_cp,
+                            )
+                        else:
+                            query = inference_context.apply_rotary_emb_query(
+                                query, q_pos_emb, self.config, cu_seqlens_q, self.pg_collection.cp
+                            )
+                if k_pos_emb is not None:
+                    use_sglang_rope = (
+                        HAVE_SGLANG_ROPE and is_sglang_rope_enabled() and packed_seq_params is None
+                    )
+                    sglang_rope_applied = False
+                    if use_sglang_rope and sglang_apply_rotary_pos_emb_with_freqs is not None:
+                        _, k_freqs = (
+                            k_pos_emb if isinstance(k_pos_emb, tuple) else (k_pos_emb, k_pos_emb)
+                        )
+                        key = sglang_apply_rotary_pos_emb_with_freqs(
+                            key, k_freqs, self.config, layer_number=self.layer_number
+                        )
+                        sglang_rope_applied = True
+                    if not sglang_rope_applied:
+                        key = apply_rotary_pos_emb(
+                            key,
+                            k_pos_emb,
                             config=self.config,
-                            cu_seqlens=cu_seqlens_q,
+                            cu_seqlens=cu_seqlens_kv,
                             mscale=_yarn_get_concentration_factor_from_config(self.config),
                             cp_group=self.pg_collection.cp,
+                            ulysses_cp=ulysses_cp,
                         )
-                    else:
-                        query = inference_context.apply_rotary_emb_query(
-                            query, q_pos_emb, self.config, cu_seqlens_q, self.pg_collection.cp
-                        )
-                if k_pos_emb is not None:
-                    key = apply_rotary_pos_emb(
-                        key,
-                        k_pos_emb,
-                        config=self.config,
-                        cu_seqlens=cu_seqlens_kv,
-                        mscale=_yarn_get_concentration_factor_from_config(self.config),
-                        cp_group=self.pg_collection.cp,
-                    )
             else:
                 query, key, value = apply_fused_qkv_rotary_pos_emb(
                     mixed_qkv, q_pos_emb, k_pos_emb, qkv_split_arg_list
@@ -1129,6 +1239,16 @@ class Attention(MegatronModule, ABC):
             # otherwise, only relative positional embedding takes effect
             # value_layer = apply_rotary_pos_emb(value_layer, k_pos_emb)
         nvtx_range_pop(suffix="rotary_pos_emb")
+
+        true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
+        if true_on_policy_policy.cast_qk_after_rope_to_dense_math_dtype:
+            # SGLang Qwen3 casts Q/K after QK RMSNorm and RoPE, before attention.
+            query = _sglang_cast_dense_tensor_math_input(query)
+            key = _sglang_cast_dense_tensor_math_input(key)
+        if split_qkv:
+            _register_attention_grad_debug(query, layer_number=self.layer_number, name="query")
+            _register_attention_grad_debug(key, layer_number=self.layer_number, name="key")
+            _register_attention_grad_debug(value, layer_number=self.layer_number, name="value")
 
         # ==================================
         # core attention computation
@@ -1197,6 +1317,9 @@ class Attention(MegatronModule, ABC):
             # t is the pack size = sum (sq_i)
             # note that batch is a dummy dimension in the packed case
             core_attn_out = core_attn_out.reshape(core_attn_out.size(0), 1, -1)
+        _register_attention_grad_debug(
+            core_attn_out, layer_number=self.layer_number, name="core_attn_out"
+        )
         nvtx_range_pop(suffix="core_attention")
 
         # Output gate
@@ -1211,6 +1334,9 @@ class Attention(MegatronModule, ABC):
         nvtx_range_push(suffix="linear_proj")
         with off_interface(self.offload_attn_proj, core_attn_out, "attn_proj") as core_attn_out:
             output, bias = self.linear_proj(core_attn_out)
+        _register_attention_grad_debug(
+            output, layer_number=self.layer_number, name="linear_proj_output"
+        )
         if self.offload_attn_proj:
             output = off_interface.group_commit(
                 output, name="attn_proj", forced_released_tensors=[core_attn_out]
@@ -1389,6 +1515,10 @@ class SelfAttention(Attention):
         If `output_gate` is True, then also derives `gate` tensor.
         If `split_qkv=False`, then the unsplit mixed_qkv tensor is returned.
         """
+        true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
+        if true_on_policy_policy.cast_attention_input_to_dense_math_dtype:
+            hidden_states = _sglang_cast_dense_tensor_math_input(hidden_states)
+
         # If no output gate: Attention heads [sq, b, h] --> [sq, b, ng * (np/ng + 2) * hn)]
         # If have output gate: Attention heads [sq, b, h] --> [sq, b, ng * (2 * np/ng + 2) * hn)]
         mixed_qkv, _ = apply_module(self.linear_qkv)(hidden_states)

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1621,16 +1621,6 @@ class SelfAttention(Attention):
         if output_gate:
             # Gate [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
             gate = gate.reshape(*gate.shape[:2], -1, self.hidden_size_per_attention_head)
-            if self.config.num_query_groups < self.world_size:
-                # gate has the same head layout as query before slicing.
-                # Apply the same TP slice so gate matches the per-rank query.
-                idx = get_tensor_model_parallel_rank() % (
-                    self.world_size // self.config.num_query_groups
-                )
-                size = self.num_attention_heads_per_partition // (
-                    self.world_size // self.config.num_query_groups
-                )
-                gate = gate[:, :, idx * size : (idx + 1) * size, :]
             return query, key, value, gate
 
         return query, key, value

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -316,7 +316,7 @@ def fused_qk_topk_naive(
     # =========================================
     # Select top-k indices
     # =========================================
-    topk_k = min(index_topk, seqlen)
+    topk_k = min(index_topk, index_scores.size(-1))
     # [batch, seqlen, index_topk]
     topk_indices = index_scores.topk(topk_k, dim=-1)[1]
 
@@ -687,6 +687,7 @@ class DSAIndexer(MegatronModule):
             pg_collection (ProcessGroupCollection, optional): Process groups for the indexer.
         """
         super().__init__(config=config)
+        self.dsv4_mode = config.dsv4_mode
         self.hidden_size = self.config.hidden_size
         self.qk_pos_emb_head_dim = self.config.qk_pos_emb_head_dim
         self.q_lora_rank = (
@@ -743,26 +744,27 @@ class DSAIndexer(MegatronModule):
             parallel_mode="duplicated",
         )
 
-        self.linear_wk = build_module(
-            submodules.linear_wk,
-            self.hidden_size,
-            self.index_head_dim,
-            config=self.config,
-            init_method=self.config.init_method,
-            bias=False,
-            skip_bias_add=False,
-            skip_weight_param_allocation=False,
-            parallel_mode="duplicated",
-        )
+        if not self.dsv4_mode:
+            self.linear_wk = build_module(
+                submodules.linear_wk,
+                self.hidden_size,
+                self.index_head_dim,
+                config=self.config,
+                init_method=self.config.init_method,
+                bias=False,
+                skip_bias_add=False,
+                skip_weight_param_allocation=False,
+                parallel_mode="duplicated",
+            )
 
-        k_norm_config = copy.copy(self.config)
-        k_norm_config.normalization = "LayerNorm"
-        self.k_norm = build_module(
-            submodules.k_norm,
-            config=k_norm_config,
-            hidden_size=self.index_head_dim,
-            eps=self.config.layernorm_epsilon,
-        )
+            k_norm_config = copy.copy(self.config)
+            k_norm_config.normalization = "LayerNorm"
+            self.k_norm = build_module(
+                submodules.k_norm,
+                config=k_norm_config,
+                hidden_size=self.index_head_dim,
+                eps=self.config.layernorm_epsilon,
+            )
 
         self.linear_weights_proj = build_module(
             submodules.linear_weights_proj,
@@ -775,6 +777,30 @@ class DSAIndexer(MegatronModule):
             skip_weight_param_allocation=False,
             parallel_mode="duplicated",
         )
+
+        # V4-specific: compressor for key computation and custom RoPE
+        if self.dsv4_mode:
+            from miles_plugins.models.deepseek_v4.ops.compressor import DeepSeekV4Compressor
+            from miles_plugins.models.deepseek_v4.ops.utils import wrapped_precompute_freqs_cis
+            from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
+            self._fp8_simulate_qat = fp8_simulate_qat
+
+            self.compress_ratio = 4
+            self.compressor = DeepSeekV4Compressor(
+                config=self.config,
+                head_dim=self.index_head_dim,
+                compress_ratio=self.compress_ratio,
+                rotate=True,
+                cp_group=pg_collection.cp,
+            )
+
+            self.rope_head_dim = config.qk_pos_emb_head_dim
+            rope_base = config.dsv4_compress_rope_theta if self.compress_ratio else config.rotary_base
+            freqs_cis = wrapped_precompute_freqs_cis(config, rope_head_dim=self.rope_head_dim, base=rope_base)
+            self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+
+            from miles.utils.replay_base import indexer_replay_manager
+            indexer_replay_manager.register_to_module(self, "indexer_replay")
 
     def _apply_rope(self, x: torch.Tensor, rotary_pos_emb: torch.Tensor, mscale: float):
         """Apply RoPE to the input tensor."""
@@ -802,14 +828,15 @@ class DSAIndexer(MegatronModule):
         # =========================================
         # Prepare RoPE params
         # =========================================
-        rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
-            None, None, x, self.config, packed_seq_params
-        )
-        if self.config.rope_type == "rope":
-            rotary_pos_emb = self.rotary_pos_emb(rotary_seq_len, packed_seq=False)
-            mscale = 1.0
-        else:
-            rotary_pos_emb, mscale = self.rotary_pos_emb(rotary_seq_len, packed_seq=False)
+        if not self.dsv4_mode:
+            rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
+                None, None, x, self.config, packed_seq_params
+            )
+            if self.config.rope_type == "rope":
+                rotary_pos_emb = self.rotary_pos_emb(rotary_seq_len, packed_seq=False)
+                mscale = 1.0
+            else:
+                rotary_pos_emb, mscale = self.rotary_pos_emb(rotary_seq_len, packed_seq=False)
 
         # =========================================
         # Gather inputs if sp is enabled
@@ -831,25 +858,48 @@ class DSAIndexer(MegatronModule):
         # [seqlen, batch, index_n_heads * index_head_dim]
         #   -> [seqlen, batch, index_n_heads, index_head_dim]
         q = q.reshape(seqlen, bsz, self.index_n_heads, self.index_head_dim)
-        q = self._apply_rope(q, rotary_pos_emb, mscale)
+        if self.dsv4_mode:
+            import einops
+            from miles_plugins.models.deepseek_v4.ops.cp_utils import get_freqs_cis_for_cp
+            from miles_plugins.models.deepseek_v4.ops.ref_model import apply_rotary_emb
+
+            rd = self.rope_head_dim
+            cp_size = parallel_state.get_context_parallel_world_size()
+            freqs_cis = get_freqs_cis_for_cp(
+                self.freqs_cis, seqlen, cp_size, self.pg_collection.cp, stride=1
+            )
+            q = q.clone()
+            q = einops.rearrange(q, 's b ... -> b s ...')
+            apply_rotary_emb(q[..., -rd:], freqs_cis)
+            q = einops.rearrange(q, 'b s ... -> s b ...')
+        else:
+            q = self._apply_rope(q, rotary_pos_emb, mscale)
 
         # =========================================
         # k linear and apply rope to k
         # =========================================
-        # [seqlen, batch, hidden_size] -> [seqlen, batch, index_head_dim]
-        k, _ = self.linear_wk(x)
-        k = self.k_norm(k)
-        # [seqlen, batch, index_head_dim] -> [seqlen, batch, 1, index_head_dim]
-        k = k.reshape(seqlen, bsz, 1, self.index_head_dim)
-        k = self._apply_rope(k, rotary_pos_emb, mscale)
-        # [seqlen, batch, 1, index_head_dim] -> [seqlen, batch, index_head_dim]
-        k = k.reshape(seqlen, bsz, self.index_head_dim)
+        if self.dsv4_mode:
+            k = self.compressor(x)
+        else:
+            # [seqlen, batch, hidden_size] -> [seqlen, batch, index_head_dim]
+            k, _ = self.linear_wk(x)
+            k = self.k_norm(k)
+            # [seqlen, batch, index_head_dim] -> [seqlen, batch, 1, index_head_dim]
+            k = k.reshape(seqlen, bsz, 1, self.index_head_dim)
+            k = self._apply_rope(k, rotary_pos_emb, mscale)
+            # [seqlen, batch, 1, index_head_dim] -> [seqlen, batch, index_head_dim]
+            k = k.reshape(seqlen, bsz, self.index_head_dim)
 
         # =========================================
         # Rotate activation
         # =========================================
         q = rotate_activation(q)
-        k = rotate_activation(k)
+        if hasattr(self, '_fp8_simulate_qat'):
+            import os
+            if os.environ.get("MEGATRON_USE_KV_QAT", "0") == "1":
+                q = self._fp8_simulate_qat(q, block_size=128)
+        if not self.dsv4_mode:
+            k = rotate_activation(k)
 
         # =========================================
         # Prepare weights for index scores
@@ -891,6 +941,17 @@ class DSAIndexer(MegatronModule):
 
         # [batch, seqlen, seqlen], [batch, seqlen, index_topk]
         index_scores, topk_indices = fused_qk_topk_naive(q, k, weights, self.index_topk, mask)
+
+        # V4 mode: apply indexer replay if registered
+        if self.dsv4_mode:
+            from miles.utils.replay_base import indexer_replay_manager
+
+            def _original_topk(scores, k, **kwargs):
+                k = min(k, scores.size(-1))
+                return scores.topk(k, dim=-1)[1]
+
+            topk_fn = indexer_replay_manager.get_topk_fn(_original_topk, return_probs=False)
+            topk_indices = topk_fn(index_scores, self.index_topk)
 
         return index_scores, topk_indices
 

--- a/megatron/core/transformer/linear_cross_entropy.py
+++ b/megatron/core/transformer/linear_cross_entropy.py
@@ -6,6 +6,7 @@ import torch
 
 from megatron.core import tensor_parallel
 from megatron.core.fusions.fused_linear_cross_entropy import linear_cross_entropy
+from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
 
 
 class LinearCrossEntropyModule(tensor_parallel.ColumnParallelLinear):
@@ -25,11 +26,20 @@ class LinearCrossEntropyModule(tensor_parallel.ColumnParallelLinear):
         ignore_index: int = -100,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Optional[torch.Tensor]]]:
         """Run either the plain ColumnParallelLinear or fused linear+cross-entropy."""
+        weight = weight if weight is not None else self.weight
+        policy = resolve_true_on_policy_runtime_policy(self.config)
+        if (
+            policy.cast_lm_head_input_to_weight_dtype
+            and weight is not None
+            and input_.dtype != weight.dtype
+        ):
+            input_ = input_.to(weight.dtype)
+
         if output_cross_entropy_loss:
             assert labels is not None, "labels cannot be None when outputting cross-entropy loss."
             return self._compute_linear_and_cross_entropy_loss(
                 hidden=input_,
-                weight=weight if weight is not None else self.weight,
+                weight=weight,
                 labels=labels,
                 reduction=reduction,
                 ignore_index=ignore_index,

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -2,6 +2,7 @@
 
 import gc
 import logging
+import os
 import warnings
 from dataclasses import dataclass
 from typing import Optional, Union
@@ -152,12 +153,74 @@ class MLP(MegatronModule):
             tp_group=tp_group,
         )
 
+    def _register_activation_grad_debug(self, tensor: torch.Tensor, name: str) -> None:
+        debug_dir = os.environ.get("MILES_ACTIVATION_GRAD_DEBUG_DIR")
+        if not debug_dir or not torch.is_tensor(tensor) or not tensor.requires_grad:
+            return
+
+        layer_number = getattr(self, "layer_number", -1)
+        debug_key = f"mlp:{layer_number}:{name}"
+
+        def _hook(grad: torch.Tensor) -> torch.Tensor:
+            if torch.isfinite(grad).all().item():
+                return grad
+
+            seen = getattr(self, "_activation_grad_debug_seen", set())
+            if debug_key in seen:
+                return grad
+            seen.add(debug_key)
+            self._activation_grad_debug_seen = seen
+
+            if torch.distributed.is_available() and torch.distributed.is_initialized():
+                rank = torch.distributed.get_rank()
+            else:
+                rank = -1
+
+            flat = grad.detach().view(-1)
+            finite = torch.isfinite(flat)
+            stats = {
+                "rank": rank,
+                "layer_number": layer_number,
+                "module": "mlp",
+                "name": name,
+                "shape": tuple(grad.shape),
+                "dtype": str(grad.dtype),
+                "numel": flat.numel(),
+                "finite": int(finite.sum().item()),
+                "nan": int(torch.isnan(flat).sum().item()),
+                "inf": int(torch.isinf(flat).sum().item()),
+            }
+            if stats["finite"] > 0:
+                finite_values = flat[finite].float()
+                stats.update(
+                    {
+                        "max_abs_finite": float(finite_values.abs().max().item()),
+                        "min_finite": float(finite_values.min().item()),
+                        "max_finite": float(finite_values.max().item()),
+                    }
+                )
+
+            os.makedirs(debug_dir, exist_ok=True)
+            path = os.path.join(
+                debug_dir,
+                f"rank_{rank}_layer_{layer_number}_mlp_{name}_pid_{os.getpid()}.pt",
+            )
+            torch.save(stats, path)
+            print(
+                f"[MILES_ACTIVATION_GRAD_DEBUG] {stats} wrote {path}",
+                flush=True,
+            )
+            return grad
+
+        tensor.register_hook(_hook)
+
     def forward(self, hidden_states, per_token_scale=None, **kwargs):
         """Perform the forward pass through the MLP block."""
         # [s, b, 4 * h/p]
         nvtx_range_push(suffix="linear_fc1")
         intermediate_parallel, bias_parallel = self.linear_fc1(hidden_states)
         nvtx_range_pop(suffix="linear_fc1")
+        self._register_activation_grad_debug(intermediate_parallel, "fc1_output")
 
         nvtx_range_push(suffix="activation")
         if self.config.use_te_activation_func:
@@ -234,12 +297,14 @@ class MLP(MegatronModule):
                 intermediate_parallel = intermediate_parallel * per_token_scale.unsqueeze(-1)
                 intermediate_parallel = intermediate_parallel.to(original_dtype)
         nvtx_range_pop(suffix="activation")
+        self._register_activation_grad_debug(intermediate_parallel, "activation_output")
 
         # [s, b, h]
         nvtx_range_push(suffix="linear_fc2")
 
         output, output_bias = self.linear_fc2(intermediate_parallel)
         nvtx_range_pop(suffix="linear_fc2")
+        self._register_activation_grad_debug(output, "fc2_output")
 
         if per_token_scale is not None and output_bias is not None:
             # if this MLP is an expert, and bias is required, we add the bias to output directly

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -334,6 +334,9 @@ def apply_swiglu_sharded_factory(
 
     def sh_ten_merge_fn(sub_state_dict):
         with torch.no_grad():
+            from megatron.training import get_args
+            if get_args().low_memory_resume:
+                return torch.cat([t.cpu() for t in sub_state_dict])
             try:
                 return torch.cat(sub_state_dict)
             except (RuntimeError, torch.cuda.OutOfMemoryError) as e:

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -430,6 +430,13 @@ class Float16Module(MegatronModule):
         self.vp_stage = getattr(module, 'vp_stage', None)
         self.pg_collection = getattr(module, 'pg_collection', None)
 
+        # Snapshot FP32 params marked with _keep_fp32 before precision conversion
+        fp32_params = {}
+        for name, param in module.named_parameters():
+            if getattr(param, '_keep_fp32', False):
+                assert param.dtype == torch.float32
+                fp32_params[name] = param.data.clone()
+
         if self.fp16:
             self.add_module('module', module.half())
 
@@ -444,6 +451,11 @@ class Float16Module(MegatronModule):
 
         else:
             raise Exception('Either config.fp16 or config.bf16 should be True.')
+
+        # Restore FP32 params after precision conversion
+        for name, param in self.module.named_parameters():
+            if name in fp32_params:
+                param.data = fp32_params[name]
 
         self.float16_convertor = float16_convertor
 

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -125,6 +125,10 @@ class BaseMoELayer(MegatronModule, ABC):
         self.layer_number = layer_number
         self.router.set_layer_number(layer_number)
 
+    def set_is_mtp(self):
+        """Mark this MoE layer as an MTP layer."""
+        self.router.is_mtp = True
+
 
 class MoELayer(BaseMoELayer):
     """Mixture of Experts layer.

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -167,7 +167,7 @@ class MoELayer(BaseMoELayer):
         self.tp_group = pg_collection.tp
 
         # Initialize router.
-        self.router = submodules.router(config=self.config, pg_collection=pg_collection)
+        self.router = submodules.router(config=self.config, pg_collection=pg_collection, layer_number=layer_number)
         self.tp_group = pg_collection.tp
 
         # Initialize latent projections.
@@ -247,13 +247,16 @@ class MoELayer(BaseMoELayer):
         self.fwd_execution_map = ["route", "expert_compute", "postprocess"]
 
     @maybe_skip_or_early_return_by_cudagraph("route")
-    def route(self, hidden_states: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
+    def route(self, hidden_states: torch.Tensor, padding_mask: Optional[torch.Tensor] = None, input_ids: Optional[torch.Tensor] = None):
         """Compute token routing for preprocessing.
 
         This method uses the router to determine which experts to send each token to,
         producing routing probabilities and a mapping.
         """
-        probs, routing_map = apply_module(self.router)(hidden_states, padding_mask)
+        if input_ids is not None and self.config.sequence_parallel:
+            from megatron.core.tensor_parallel.mappings import split_along_nth_dim
+            input_ids = split_along_nth_dim(input_ids, dim=1, group=parallel_state.get_tensor_model_parallel_group())
+        probs, routing_map = apply_module(self.router)(hidden_states, padding_mask, input_ids=input_ids)
         return probs, routing_map
 
     @maybe_skip_or_early_return_by_cudagraph("preprocess")
@@ -363,6 +366,7 @@ class MoELayer(BaseMoELayer):
         hidden_states: torch.Tensor,
         intermediate_tensors=None,
         padding_mask: Optional[torch.Tensor] = None,
+        input_ids: Optional[torch.Tensor] = None,
     ):
         """Forward pass for the MoE layer.
 
@@ -377,6 +381,7 @@ class MoELayer(BaseMoELayer):
             padding_mask (torch.Tensor, optional): Boolean mask indicating non-padding tokens.
                                                    Shape [seq_length, bsz]. True for valid tokens,
                                                    False for padding tokens. Defaults to None.
+            input_ids (torch.Tensor, optional): Input token IDs for hash routing.
         Returns:
             A tuple containing the output tensor and the MLP bias, if any.
         """
@@ -390,11 +395,11 @@ class MoELayer(BaseMoELayer):
             padding_mask = padding_mask.transpose(0, 1).bool()
 
         # MoE forward: route -> dispatch -> compute -> combine
-        def custom_forward(hidden_states, intermediate_tensors, padding_mask=None):
+        def custom_forward(hidden_states, intermediate_tensors, padding_mask=None, input_ids=None):
             try:
                 if "route" in self.fwd_execution_map:
                     shared_expert_output = self.shared_experts_compute(hidden_states)
-                    probs, routing_map = self.route(hidden_states, padding_mask)
+                    probs, routing_map = self.route(hidden_states, padding_mask, input_ids=input_ids)
                     hidden_states, probs = self.preprocess(hidden_states, probs, routing_map)
 
                     if intermediate_tensors is not None:
@@ -448,7 +453,7 @@ class MoELayer(BaseMoELayer):
                     custom_forward, False, hidden_states, padding_mask
                 )
         else:
-            outputs = custom_forward(hidden_states, intermediate_tensors, padding_mask)
+            outputs = custom_forward(hidden_states, intermediate_tensors, padding_mask, input_ids=input_ids)
 
         return outputs
 

--- a/megatron/core/transformer/moe/moe_utils.py
+++ b/megatron/core/transformer/moe/moe_utils.py
@@ -620,6 +620,8 @@ def topk_routing_with_score_function(
     expert_bias: Optional[torch.Tensor] = None,
     fused: bool = False,
     is_mtp: bool = False,
+    tid2eid: Optional[torch.Tensor] = None,
+    input_ids: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Compute the routing probabilities and map for top-k selection with score function.
 
@@ -700,7 +702,8 @@ def topk_routing_with_score_function(
     from miles.utils.replay_base import routing_replay_manager
 
     # MTP layers cannot use rollout routing replay
-    if not is_mtp:
+    # Hash-routed layers (tid2eid is not None) also bypass replay since routing is deterministic
+    if not is_mtp and tid2eid is None:
         compute_topk = routing_replay_manager.get_topk_fn(_compute_topk, return_probs=True)
     else:
         compute_topk = _compute_topk
@@ -721,6 +724,22 @@ def topk_routing_with_score_function(
         else:
             scores, top_indices = compute_topk(scores, topk, num_groups, group_topk)
         probs = scores / (scores.sum(dim=-1, keepdim=True) + 1e-20) if topk > 1 else scores
+    elif score_function == "sqrtsoftplus":
+        assert num_groups is None
+        assert group_topk is None
+        scores = torch.nn.functional.softplus(logits.float()).sqrt().type_as(logits)
+        if tid2eid is not None:
+            assert not tid2eid.requires_grad
+            assert input_ids is not None and not input_ids.requires_grad
+            top_indices = tid2eid[input_ids]
+            assert torch.all(top_indices >= 0)
+        else:
+            assert expert_bias is not None
+            scores_for_routing = scores + expert_bias
+            assert len(scores_for_routing.shape) == 2
+            _, top_indices = compute_topk(scores_for_routing, topk, num_groups, group_topk)
+        scores = torch.gather(scores, dim=1, index=top_indices).type_as(logits)
+        probs = scores / (scores.sum(dim=-1, keepdim=True) + 1e-20)
     else:
         raise ValueError(f"Invalid score_function: {score_function}")
 

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -65,6 +65,11 @@ class Router(ABC, MegatronModule):
         self.calculate_per_token_loss = self.config.calculate_per_token_loss
         self.reset_parameters()
 
+        if self.config.moe_router_freeze_gate:
+            self.weight.requires_grad = False
+            if self.bias is not None:
+                self.bias.requires_grad = False
+
     def reset_parameters(self):
         """Reset the router parameters."""
         if self.config.perform_initialization:
@@ -91,6 +96,11 @@ class Router(ABC, MegatronModule):
             self.weight.data = self.weight.data.to(device=torch.cuda.current_device())
         if self.bias is not None and self.bias.device.type == 'cpu':
             self.bias.data = self.bias.data.to(device=torch.cuda.current_device())
+
+        if self.config.moe_router_freeze_gate:
+            assert not self.weight.requires_grad
+            if self.bias is not None:
+                assert not self.bias.requires_grad
 
         # Convert to specified datatype for routing computation if enabled
         router_dtype = input.dtype
@@ -146,42 +156,33 @@ class TopKRouter(Router):
     """
 
     def __init__(
-        self, config: TransformerConfig, pg_collection: Optional[ProcessGroupCollection] = None
+        self, config: TransformerConfig, pg_collection: Optional[ProcessGroupCollection] = None, layer_number: int = None
     ) -> None:
         """Initialize the zero token dropping router.
 
         Args:
             config (TransformerConfig): The configuration for the transformer model.
             pg_collection (ProcessGroupCollection, optional): Process groups for MoE operations.
+            layer_number (int, optional): The layer number for this router.
         """
         super().__init__(config=config, pg_collection=pg_collection)
+        self.layer_number = layer_number
         self.topk = self.config.moe_router_topk
         self.routing_type = self.config.moe_router_load_balancing_type
         self.score_function = self.config.moe_router_score_function
         self.input_jitter = None
 
-        self.enable_expert_bias = self.config.moe_router_enable_expert_bias
-        if self.enable_expert_bias:
-            self.register_buffer(
-                'local_tokens_per_expert',
-                torch.zeros(
-                    self.config.num_moe_experts,
-                    dtype=torch.float32,
-                    device=torch.cuda.current_device(),
-                ),
-                persistent=False,
-            )
-            self.register_buffer(
-                'expert_bias',
-                torch.zeros(
-                    self.config.num_moe_experts,
-                    dtype=torch.float32,
-                    device=torch.cuda.current_device(),
-                ),
-            )
-        else:
-            self.local_tokens_per_expert = None
-            self.expert_bias = None
+        # Routing mode (expert_bias vs tid2eid) depends on layer_number, which
+        # may not be known at construction time — Megatron's TransformerLayer
+        # calls build_module(MoELayer) without layer_number, then immediately
+        # calls set_layer_number().  We defer creation to _init_routing_mode()
+        # and assert it has been called before the first forward pass.
+        self._routing_mode_initialized = False
+        self.enable_expert_bias = False
+        self.tid2eid = None
+        self._frozen_expert_bias_snapshot = None
+        if layer_number is not None:
+            self._init_routing_mode(layer_number)
 
         # Initialize global tokens per expert for global aux loss
         if self.get_aux_loss_coeff("global_aux_loss") > 0:
@@ -205,6 +206,55 @@ class TopKRouter(Router):
 
         from miles.utils.replay_base import routing_replay_manager
         routing_replay_manager.register_to_module(self, "routing_replay")
+
+    def _init_routing_mode(self, layer_number):
+        assert not self._routing_mode_initialized
+        self._routing_mode_initialized = True
+
+        mode_hash = layer_number <= self.config.dsv4_n_hash_layers
+
+        self.enable_expert_bias = (
+            self.config.moe_router_enable_expert_bias and not mode_hash
+        )
+        if self.enable_expert_bias:
+            self.register_buffer(
+                'local_tokens_per_expert',
+                torch.zeros(
+                    self.config.num_moe_experts,
+                    dtype=torch.float32,
+                    device=torch.cuda.current_device(),
+                ),
+                persistent=False,
+            )
+            self.register_buffer(
+                'expert_bias',
+                torch.zeros(
+                    self.config.num_moe_experts,
+                    dtype=torch.float32,
+                    device=torch.cuda.current_device(),
+                ),
+            )
+        else:
+            self.local_tokens_per_expert = None
+            self.expert_bias = None
+
+        if self.config.freeze_e_score_correction_bias and self.enable_expert_bias:
+            self._frozen_expert_bias_snapshot = None
+
+        if mode_hash:
+            self.tid2eid = torch.nn.Parameter(
+                torch.full(
+                    (self.config.vocab_size, self.topk),
+                    fill_value=-1,
+                    dtype=torch.int32,
+                ),
+                requires_grad=False,
+            )
+
+    def set_layer_number(self, layer_number: int):
+        self.layer_number = layer_number
+        if not self._routing_mode_initialized:
+            self._init_routing_mode(layer_number)
 
     def _maintain_float32_expert_bias(self):
         """
@@ -543,7 +593,7 @@ class TopKRouter(Router):
                     routing_map = routing_map & (~padding_mask)
                 self.local_tokens_per_expert += routing_map.sum(dim=0)
 
-    def routing(self, logits: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
+    def routing(self, logits: torch.Tensor, padding_mask: Optional[torch.Tensor] = None, input_ids: Optional[torch.Tensor] = None):
         """Top-k routing function
 
         Args:
@@ -551,12 +601,16 @@ class TopKRouter(Router):
             padding_mask (torch.Tensor, optional): Boolean mask indicating non-padding tokens.
                                                    Shape [seq_length, bsz]. True for valid tokens,
                                                    False for padding tokens. Defaults to None.
+            input_ids (torch.Tensor, optional): Input token IDs for hash routing.
 
         Returns:
             probs (torch.Tensor): The probabilities of token to experts assignment.
             routing_map (torch.Tensor): The mapping of token to experts assignment,
                 with shape [num_tokens, num_experts].
         """
+        if self.config.dsv4_mode:
+            assert self._routing_mode_initialized
+
         seq_length, bsz = logits.shape[:2]
         logits = logits.view(-1, self.config.num_moe_experts)
 
@@ -582,6 +636,8 @@ class TopKRouter(Router):
                 expert_bias=self.expert_bias,
                 fused=self.config.moe_router_fusion,
                 is_mtp=self.is_mtp,
+                tid2eid=self.tid2eid,
+                input_ids=input_ids.view(-1) if self.tid2eid is not None and input_ids is not None else None,
             )
 
         # Apply token dropping to probs and routing_map.
@@ -637,7 +693,7 @@ class TopKRouter(Router):
             self.global_tokens_per_expert.zero_()
             self.ga_steps.zero_()
 
-    def forward(self, input: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
+    def forward(self, input: torch.Tensor, padding_mask: Optional[torch.Tensor] = None, input_ids: Optional[torch.Tensor] = None):
         """
         Forward pass of the router.
 
@@ -646,8 +702,16 @@ class TopKRouter(Router):
             padding_mask (torch.Tensor, optional): Boolean mask indicating non-padding tokens.
                                                    Shape [seq_length, bsz]. True for valid tokens,
                                                    False for padding tokens. Defaults to None.
+            input_ids (torch.Tensor, optional): Input token IDs for hash routing.
         """
         self._maintain_float32_expert_bias()
+
+        if self.config.freeze_e_score_correction_bias and self.enable_expert_bias:
+            if self._frozen_expert_bias_snapshot is None:
+                self._frozen_expert_bias_snapshot = self.expert_bias.clone()
+            else:
+                assert torch.equal(self.expert_bias, self._frozen_expert_bias_snapshot), \
+                    "expert_bias was modified but freeze_e_score_correction_bias is enabled!"
 
         # Apply input jitter
         input = self.apply_input_jitter(input)
@@ -663,7 +727,7 @@ class TopKRouter(Router):
                 logits, self.config.moe_router_force_biased, self.layer_number
             )
 
-        probs, routing_map = self.routing(logits, padding_mask=padding_mask)
+        probs, routing_map = self.routing(logits, padding_mask=padding_mask, input_ids=input_ids)
 
         return probs, routing_map
 

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -47,6 +47,9 @@ class SharedExpertMLP(MLP):
         assert config.add_bias_linear == False, "bias is not supported in the shared experts, "
         "please set '--disable-bias-linear' instead."
 
+        if not config.activation_func_clamp_shared_expert:
+            config.activation_func_clamp_value = None
+
         config.ffn_hidden_size = config.moe_shared_expert_intermediate_size
         # TODO(Hepteract): pass pg_collection to MLP after refactoring MLP
         super().__init__(config=config, submodules=submodules, tp_group=pg_collection.tp)

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -283,8 +283,8 @@ class MultiLatentAttention(Attention):
         else:
             if inference_context is None or inference_context.is_static_batching():
                 extra_kwargs = {}
-                if self.config.experimental_attention_variant == "dsa":
-                    # For dsa we need to pass in the original hidden states and the compressed
+                if self.config.experimental_attention_variant in ("dsa", "dsv4"):
+                    # For dsa/dsv4 we need to pass in the original hidden states and the compressed
                     # query representation.
                     extra_kwargs["x"] = hidden_states
                     extra_kwargs["qr"] = q_compressed

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -670,6 +670,8 @@ class MultiTokenPredictionLayer(MegatronModule):
             vp_stage=vp_stage,
             layer_number=self.layer_number + diff_transformer_layer_offset,
         )
+        if hasattr(self.transformer_layer.mlp, 'set_is_mtp'):
+            self.transformer_layer.mlp.set_is_mtp()
 
         self.final_layernorm = build_module(
             self.submodules.layer_norm,

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -7,6 +7,7 @@ from typing import Callable, List, Optional, Union
 
 import torch
 from torch import Tensor
+import warnings
 
 from megatron.core import InferenceParams, parallel_state, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
@@ -709,17 +710,19 @@ class MultiTokenPredictionLayer(MegatronModule):
             cp_group=self.cp_group,
             packed_seq_params=packed_seq_params,
         )
-        position_ids, _ = roll_tensor(
-            position_ids,
-            shifts=-1,
-            dims=-1,
-            cp_group=self.cp_group,
-            packed_seq_params=packed_seq_params,
-        )
+        if position_ids is not None:
+            position_ids, _ = roll_tensor(
+                position_ids,
+                shifts=-1,
+                dims=-1,
+                cp_group=self.cp_group,
+                packed_seq_params=packed_seq_params,
+            )
         # embedding
         decoder_input = embedding(input_ids=input_ids, position_ids=position_ids)
+        decoder_input = decoder_input.detach()
 
-        hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
+        hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=False)
 
         return input_ids, position_ids, decoder_input, hidden_states
 
@@ -821,6 +824,51 @@ class MultiTokenPredictionLayer(MegatronModule):
         return hidden_states
 
     def _checkpointed_forward(self, forward_func, *args, **kwargs):
+        """Wrap `forward_func` with activation checkpointing while only passing tensors.
+
+        Non-tensor arguments (e.g., configuration objects, None) are captured via closure so
+        that checkpoint implementations never receive them directly, avoiding save_for_backward
+        issues with non-tensor inputs.
+        """
+
+        # TODO(jiajun): Is there any better implementation here?
+        positional_specs = []
+        kw_specs = []
+        tensor_args: List[torch.Tensor] = []
+
+        for arg in args:
+            if torch.is_tensor(arg):
+                positional_specs.append(('tensor', len(tensor_args)))
+                tensor_args.append(arg)
+            else:
+                positional_specs.append(('const', arg))
+
+        for key, value in kwargs.items():
+            if torch.is_tensor(value):
+                kw_specs.append((key, ('tensor', len(tensor_args))))
+                tensor_args.append(value)
+            else:
+                kw_specs.append((key, ('const', value)))
+
+        def run(*flat_tensor_args):
+            rebuilt_args = []
+            for spec_type, payload in positional_specs:
+                if spec_type == 'tensor':
+                    rebuilt_args.append(flat_tensor_args[payload])
+                else:
+                    rebuilt_args.append(payload)
+
+            rebuilt_kwargs = {}
+            for key, (spec_type, payload) in kw_specs:
+                if spec_type == 'tensor':
+                    rebuilt_kwargs[key] = flat_tensor_args[payload]
+                else:
+                    rebuilt_kwargs[key] = payload
+
+            return forward_func(*rebuilt_args, **rebuilt_kwargs)
+
+        tensor_args_tuple = tuple(tensor_args)
+
         def checkpoint_handler():
             """Determines whether to use the `te_checkpoint` or `tensor_parallel.checkpoint`"""
             if self.config.fp8:
@@ -831,12 +879,11 @@ class MultiTokenPredictionLayer(MegatronModule):
                     self.config.distribute_saved_activations,
                     tensor_parallel.random.get_cuda_rng_tracker,
                     parallel_state.get_tensor_model_parallel_group(),
-                    *args,
-                    **kwargs,
+                    *tensor_args_tuple,
                 )
             else:
                 return tensor_parallel.checkpoint(
-                    forward_func, self.config.distribute_saved_activations, *args, *kwargs.values()
+                    run, self.config.distribute_saved_activations, *tensor_args_tuple
                 )
 
         if self.config.recompute_method == 'uniform':

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import logging
+import os
 from contextlib import nullcontext
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List, Optional, Union
 
 import torch
 from torch import Tensor
+from torch.utils.checkpoint import checkpoint as torch_checkpoint
 
 from megatron.core import parallel_state, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
@@ -27,6 +30,8 @@ from megatron.core.transformer.transformer_layer import (
     get_transformer_layer_offset,
 )
 from megatron.core.transformer.utils import sharded_state_dict_default
+from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
+from miles_megatron_plugins.true_on_policy.sglang_backend import SGLangFinalRMSNorm, SGLangNorm
 from megatron.core.utils import (
     WrappedTensor,
     deprecate_inference_params,
@@ -70,6 +75,57 @@ else:
 
 
 logger = logging.getLogger(__name__)
+
+_FINAL_LAYERNORM_BWD_DUMP_COUNTER = 0
+_WARNED_SGLANG_CP_RECOMPUTE_FALLBACK = False
+
+
+def _maybe_dump_final_layernorm_backward(name: str, tensor: Optional[Tensor]) -> None:
+    dump_dir = os.environ.get("MILES_FINAL_LAYERNORM_BACKWARD_DEBUG_DIR")
+    if not dump_dir or tensor is None or not tensor.requires_grad:
+        return
+
+    def hook(grad: Tensor) -> Tensor:
+        global _FINAL_LAYERNORM_BWD_DUMP_COUNTER
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        finite_mask = torch.isfinite(grad)
+        finite = grad[finite_mask]
+        stats = {
+            "rank": rank,
+            "name": name,
+            "shape": tuple(grad.shape),
+            "dtype": str(grad.dtype),
+            "numel": grad.numel(),
+            "finite": finite_mask.sum().item(),
+            "nan": torch.isnan(grad).sum().item(),
+            "inf": torch.isinf(grad).sum().item(),
+        }
+        if finite.numel() > 0:
+            finite_f = finite.float()
+            stats.update(
+                {
+                    "max_abs_finite": finite_f.abs().max().item(),
+                    "min_finite": finite_f.min().item(),
+                    "max_finite": finite_f.max().item(),
+                }
+            )
+        else:
+            stats.update({"max_abs_finite": None, "min_finite": None, "max_finite": None})
+
+        counter = _FINAL_LAYERNORM_BWD_DUMP_COUNTER
+        _FINAL_LAYERNORM_BWD_DUMP_COUNTER += 1
+        path = Path(dump_dir) / f"rank_{rank}_{counter:05d}_{name}.pt"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({"stats": stats}, path)
+        print(f"[MILES_FINAL_LAYERNORM_BACKWARD_DEBUG] {stats} wrote {path}", flush=True)
+        return grad
+
+    tensor.register_hook(hook)
+
+
+def _get_sglang_cp_recompute_mode() -> str:
+    mode = os.environ.get("MEGATRON_TRUE_ON_POLICY_SGLANG_CP_RECOMPUTE", "disabled")
+    return mode.lower().replace("-", "_")
 
 
 def get_num_layers_to_build(
@@ -254,8 +310,15 @@ def _get_block_submodules(
             return spec.submodules
         elif issubclass(spec.module, BaseTransformerLayer):
             num_layers = get_num_layers_to_build(config, vp_stage, pp_rank)
+            layer_norm = LayerNormImpl
+            if resolve_true_on_policy_runtime_policy(config).use_sglang_final_norm:
+                layer_norm = (
+                    SGLangFinalRMSNorm
+                    if getattr(config, "normalization", None) == "RMSNorm"
+                    else SGLangNorm
+                )
             return TransformerBlockSubmodules(
-                layer_specs=[spec] * num_layers, layer_norm=LayerNormImpl
+                layer_specs=[spec] * num_layers, layer_norm=layer_norm
             )
         else:
             raise Exception(f"specialize for {spec.module.__name__}.")
@@ -502,6 +565,50 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
 
         def checkpoint_handler(forward_func):
             """Determines whether to use the `te_checkpoint` or `tensor_parallel.checkpoint`"""
+            true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
+            if true_on_policy_policy.use_ulysses_cp_recompute_fallback:
+                mode = _get_sglang_cp_recompute_mode()
+                global _WARNED_SGLANG_CP_RECOMPUTE_FALLBACK
+                if mode in ("disabled", "disable", "off", "none", "false", "0"):
+                    if not _WARNED_SGLANG_CP_RECOMPUTE_FALLBACK:
+                        logger.info(
+                            "Bypassing full activation recompute for SGLang Ulysses CP. "
+                            "Set MEGATRON_TRUE_ON_POLICY_SGLANG_CP_RECOMPUTE to "
+                            "'non_reentrant' or 'reentrant' to override."
+                        )
+                        _WARNED_SGLANG_CP_RECOMPUTE_FALLBACK = True
+                    return forward_func(
+                        hidden_states,
+                        attention_mask,
+                        context,
+                        context_mask,
+                        rotary_pos_emb,
+                        padding_mask,
+                    )
+                if mode == "non_reentrant":
+                    if not _WARNED_SGLANG_CP_RECOMPUTE_FALLBACK:
+                        logger.info(
+                            "Using non-reentrant torch checkpoint for SGLang Ulysses CP "
+                            "full recompute."
+                        )
+                        _WARNED_SGLANG_CP_RECOMPUTE_FALLBACK = True
+                    return torch_checkpoint(
+                        forward_func,
+                        hidden_states,
+                        attention_mask,
+                        context,
+                        context_mask,
+                        rotary_pos_emb,
+                        padding_mask,
+                        use_reentrant=False,
+                        preserve_rng_state=True,
+                    )
+                if mode != "reentrant":
+                    raise ValueError(
+                        "Invalid MEGATRON_TRUE_ON_POLICY_SGLANG_CP_RECOMPUTE value "
+                        f"{mode!r}; expected disabled, non_reentrant, or reentrant."
+                    )
+
             # TODO: check if fp4 is supported in this case
             if self.config.fp8 or self.config.fp4:
                 return te_checkpoint(
@@ -786,13 +893,30 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
 
         # Final layer norm.
         if self.final_layernorm is not None:
-            hidden_states = self.final_layernorm(hidden_states)
+            true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
+            sglang_residual = (
+                getattr(hidden_states, "_sglang_residual", None)
+                if true_on_policy_policy.use_sglang_residual_pair
+                else None
+            )
+            _maybe_dump_final_layernorm_backward(
+                "final_layernorm_input_hidden_states", hidden_states
+            )
+            _maybe_dump_final_layernorm_backward(
+                "final_layernorm_input_sglang_residual", sglang_residual
+            )
+            if sglang_residual is not None:
+                hidden_states, _ = self.final_layernorm(hidden_states, sglang_residual)
+            else:
+                hidden_states = self.final_layernorm(hidden_states)
+            _maybe_dump_final_layernorm_backward("final_layernorm_output", hidden_states)
             # TENorm produces a "viewed" tensor. This will result in schedule.py's
             # deallocate_output_tensor() throwing an error, so a viewless tensor is
             # created to prevent this.
             hidden_states = make_viewless_tensor(
                 inp=hidden_states, requires_grad=True, keep_graph=True
             )
+            _maybe_dump_final_layernorm_backward("final_layernorm_viewless_output", hidden_states)
 
         # If this TransformerBlock is empty, input and output hidden states will be the same node
         # on the computational graph and will lead to unexpected errors in pipeline schedules.

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -447,6 +447,16 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         else:
             self.final_layernorm = None  # Either this or nn.Identity
 
+        # DeepSeek V4 Hyper-Connection
+        if self.config.dsv4_mode:
+            from miles_plugins.models.deepseek_v4.ops.hyper_connection import (
+                DeepSeekV4HyperConnectionUtil,
+                HCHeadParams,
+            )
+            self.hc_util = DeepSeekV4HyperConnectionUtil(self.config)
+            if self.has_final_layernorm_in_this_stage():
+                self.hc_head_params = HCHeadParams(self.config)
+
         if self.config.inference_fuse_tp_communication:
             self._setup_fused_tp_communication()
 
@@ -516,6 +526,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         packed_seq_params: PackedSeqParams,
         use_inner_quantization_context: bool,
         padding_mask: Optional[Tensor] = None,
+        input_ids: Optional[Tensor] = None,
     ):
         """Forward method with activation checkpointing."""
 
@@ -527,6 +538,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                 context_mask,
                 rotary_pos_emb,
                 padding_mask=None,
+                input_ids=None,
             ):
                 for index in range(start, end):
                     layer = self._get_layer(index)
@@ -558,6 +570,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                             inference_context=None,
                             packed_seq_params=packed_seq_params,
                             padding_mask=padding_mask,
+                            input_ids=input_ids,
                         )
                 return hidden_states, context
 
@@ -622,6 +635,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     context_mask,
                     rotary_pos_emb,
                     padding_mask,
+                    input_ids,
                 )
             else:
                 return tensor_parallel.checkpoint(
@@ -633,6 +647,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     context_mask,
                     rotary_pos_emb,
                     padding_mask,
+                    input_ids,
                 )
 
         if self.config.recompute_method == 'uniform':
@@ -739,6 +754,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
         padding_mask: Optional[Tensor] = None,
+        input_ids: Optional[Tensor] = None,
         *,
         inference_params: Optional[BaseInferenceContext] = None,
         dynamic_inference_decode_only: Optional[bool] = None,
@@ -809,6 +825,10 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         #   is called here to be future-proof and corner-case-proof.
         hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
 
+        # HC expand: [s, b, d] -> [s, b, hc, d]
+        if self.config.dsv4_mode and self.pre_process:
+            hidden_states = self.hc_util.block_expand(hidden_states)
+
         if self.config.sequence_parallel:
             rng_context = tensor_parallel.get_cuda_rng_tracker().fork()
         else:
@@ -849,6 +869,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     packed_seq_params=packed_seq_params,
                     use_inner_quantization_context=use_inner_quantization_context,
                     padding_mask=padding_mask,
+                    input_ids=input_ids,
                 )
             else:
                 for l_no, layer in enumerate(self.layers):
@@ -882,6 +903,7 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                             packed_seq_params=packed_seq_params,
                             sequence_len_offset=sequence_len_offset,
                             padding_mask=padding_mask,
+                            input_ids=input_ids,
                         )
 
                     if (
@@ -890,6 +912,15 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                         and self.group_prefetch_offload_commit_async is not None
                     ):
                         hidden_states = self.group_prefetch_offload_commit_async(hidden_states)
+
+        # HC head: [s, b, hc, d] -> [s, b, d]
+        if self.config.dsv4_mode and self.post_process and hasattr(self, 'hc_head_params'):
+            hidden_states = self.hc_util.block_head(
+                hidden_states,
+                self.hc_head_params.hc_head_fn,
+                self.hc_head_params.hc_head_scale,
+                self.hc_head_params.hc_head_base,
+            )
 
         # Final layer norm.
         if self.final_layernorm is not None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -229,6 +229,9 @@ class TransformerConfig(ModelParallelConfig):
     attention_output_gate: bool = False
     """Whether to apply output gate to the attention layers."""
 
+    post_self_attn_layernorm: bool = False
+    post_mlp_layernorm: bool = False
+
     test_mode: bool = False
     """Whether to run real-time tests."""
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -505,6 +505,12 @@ class TransformerConfig(ModelParallelConfig):
     use_kitchen: bool = False
     """Use the kitchen extension for transformer quantization."""
 
+    true_on_policy_contract: Optional[str] = None
+    """Internal true-on-policy parity contract selected by the launcher."""
+
+    true_on_policy_vocab_size: Optional[int] = None
+    """Optional non-padded vocab size for SGLang-compatible scoring logits."""
+
     use_kitchen_attention: bool = False
     """Use the kitchen extension for attention (instead of TE's attention)."""
 
@@ -930,6 +936,10 @@ class TransformerConfig(ModelParallelConfig):
         details.
         """
         super().__post_init__()
+        if self.true_on_policy_contract is not None:
+            from miles_megatron_plugins.true_on_policy.contracts import validate_true_on_policy_contract
+
+            validate_true_on_policy_contract(self.true_on_policy_contract)
         if self.fp16 and self.bf16:
             raise ValueError(
                 f"Only one of self.fp16: {self.fp16} and self.bf16 {self.bf16} should be True."
@@ -2012,7 +2022,11 @@ class TransformerConfig(ModelParallelConfig):
                 f" but got {self.transformer_impl=}."
             )
 
-        if self.fallback_to_eager_attn or self.transformer_impl == "local":
+        uses_true_on_policy_backend = self.true_on_policy_contract is not None
+        local_attention_requires_all_gather_cp = (
+            self.transformer_impl == "local" and not uses_true_on_policy_backend
+        )
+        if self.fallback_to_eager_attn or local_attention_requires_all_gather_cp:
             if self.context_parallel_size > 1 and self.cp_comm_type is not None:
                 all_cp_comm_types_are_all_gather = (
                     all(item == "all_gather" for item in self.cp_comm_type)
@@ -2031,6 +2045,18 @@ class TransformerConfig(ModelParallelConfig):
             assert not self.add_bias_linear
             assert not self.add_qkv_bias
             assert not self.use_kitchen
+            assert self.true_on_policy_contract is None
+
+        if uses_true_on_policy_backend:
+            assert self.transformer_impl == "local", (
+                f"true_on_policy_contract currently requires transformer_impl='local', "
+                f"but got {self.transformer_impl=}."
+            )
+            assert (
+                not self.use_kitchen
+            ), "true_on_policy_contract is not compatible with use_kitchen."
+        if self.true_on_policy_vocab_size is not None:
+            assert self.true_on_policy_vocab_size > 0, "true_on_policy_vocab_size must be > 0."
 
         if self.inference_fuse_tp_communication:
             assert self.transformer_impl == "inference_optimized", (

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -54,6 +54,19 @@ class TransformerConfig(ModelParallelConfig):
     by using D sequential modules to predict D additional tokens.
     """
 
+    mtp_loss_type: str = 'ce'
+    """Loss used to train the MTP draft head: 'ce' (cross-entropy, default) or 'tv'
+    (total-variation distillation to the main model's next-token distribution,
+    1 - sum_v min(softmax(p_main), softmax(q_draft))). TV is the direct objective for
+    rejection-sampling acceptance rate (accept_rate = 1 - d_TV); CE only bounds it via
+    Pinsker. 'tv' requires tensor-model-parallel size 1 (full vocab per rank).
+    """
+
+    mtp_tv_chunk: int = 0
+    """For mtp_loss_type='tv': chunk size along the sequence dim for the vocab-sum,
+    to cap peak/backward memory (each chunk is gradient-checkpointed). 0 = no chunking.
+    """
+
     mtp_loss_scaling_factor: Optional[float] = 0.1
     """Weighting factor of Multi-Token Prediction (MTP) loss.
     We compute the average of the MTP losses across all depths, 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -187,6 +187,10 @@ class TransformerConfig(ModelParallelConfig):
     """Clamp the output of the linear_fc1 in the activation function. Only used when activation_func
     is quick_gelu."""
 
+    activation_func_clamp_shared_expert: bool = True
+    """If False, skip activation_func_clamp_value inside SharedExpertMLP so only routed MoE
+    experts get the clamp."""
+
     num_moe_experts: Optional[int] = None
     """Number of experts to use for MoE layer. When set, it replaces MLP with MoE layer. Set to None
     for no MoE."""
@@ -252,8 +256,8 @@ class TransformerConfig(ModelParallelConfig):
     ####################
     # attention variant
     ####################
-    experimental_attention_variant: Optional[Literal['gated_delta_net', 'dsa']] = None
-    """Type of attention variant to use. Currently support gated_delta_net and dsa."""
+    experimental_attention_variant: Optional[Literal['gated_delta_net', 'dsa', 'dsv4']] = None
+    """Type of attention variant to use. Currently support gated_delta_net, dsa, and dsv4."""
 
     ####################
     # DSA
@@ -273,6 +277,48 @@ class TransformerConfig(ModelParallelConfig):
     dsa_indexer_use_sparse_loss: bool = False
     """Whether to use sparse DSA indexer loss. If True, the indexer loss will be computed using the
     top-k indices."""
+
+    ####################
+    # DeepSeek V4
+    ####################
+    dsv4_mode: bool = False
+    """Enable DeepSeek V4 mode (MLA + MoE with window sparse attention, topk, hyper-connections)."""
+
+    dsv4_hc_mult: Optional[int] = None
+    """Hyper-Connection multiplier (number of HC streams)."""
+
+    dsv4_hc_sinkhorn_iters: int = 20
+    """Number of Sinkhorn iterations for HC doubly-stochastic normalization."""
+
+    dsv4_hc_eps: float = 1e-6
+    """Epsilon for HC Sinkhorn normalization."""
+
+    dsv4_compress_ratios: Optional[List[int]] = None
+    """Per-layer compression ratios for compressor. None or 0 means no compression."""
+
+    dsv4_compress_rope_theta: float = 40000.0
+    """RoPE theta for compressor positional embeddings."""
+
+    dsv4_o_groups: Optional[int] = None
+    """Number of output groups for grouped output projection."""
+
+    dsv4_o_lora_rank: Optional[int] = None
+    """LoRA rank for output projection."""
+
+    dsv4_n_hash_layers: int = 0
+    """Number of layers using hash routing (from layer 0). Remaining layers use learned routing."""
+
+    dsv4_window_size: int = 4096
+    """Window size for local window attention in sparse attention."""
+
+    vocab_size: Optional[int] = None
+    """Vocabulary size, passed through for hash routing tid2eid initialization."""
+
+    freeze_e_score_correction_bias: bool = False
+    """Freeze expert score correction bias during training."""
+
+    moe_router_freeze_gate: bool = False
+    """Freeze MoE router gate weights during training."""
 
     ####################
     # linear attention
@@ -637,8 +683,8 @@ class TransformerConfig(ModelParallelConfig):
     """Scaling factor for routing score in top-k selection, only works when moe_router_pre_softmax
     enabled. Defaults to None, which means no scaling."""
 
-    moe_router_score_function: Literal['softmax', 'sigmoid'] = "softmax"
-    """Score function for MoE routing. Can be "softmax" or "sigmoid"."""
+    moe_router_score_function: Literal['softmax', 'sigmoid', 'sqrtsoftplus'] = "softmax"
+    """Score function for MoE routing. Can be "softmax", "sigmoid", or "sqrtsoftplus"."""
 
     moe_router_dtype: Optional[Literal['fp32', 'fp64']] = None
     """Data type for routing and expert output weighted averaging. Using fp32 or fp64 can
@@ -980,6 +1026,9 @@ class TransformerConfig(ModelParallelConfig):
             )
             self.experimental_attention_variant = self.linear_attention_type
             self.linear_attention_type = None
+
+        if self.experimental_attention_variant == "dsv4":
+            self.dsv4_mode = True
 
         if self.experimental_attention_variant in ["gated_delta_net"]:
             assert (
@@ -1629,10 +1678,13 @@ class TransformerConfig(ModelParallelConfig):
                 self.expert_tensor_parallel_size == 1
             ), "Bias in Moe is only supported when ETP==1"
 
-        if self.moe_router_enable_expert_bias and self.moe_router_score_function != "sigmoid":
+        if self.moe_router_enable_expert_bias and self.moe_router_score_function not in (
+            "sigmoid",
+            "sqrtsoftplus",
+        ):
             raise ValueError(
-                "Expert bias for aux-loss-free routing only supports sigmoid score function."
-                "Please set --moe-router-score-function sigmoid for sigmoid score function."
+                "Expert bias for aux-loss-free routing only supports sigmoid or sqrtsoftplus score function. "
+                "Please set --moe-router-score-function to sigmoid or sqrtsoftplus."
             )
 
         if self.num_moe_experts and self.fp8:

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -23,6 +23,11 @@ from megatron.core.transformer.mlp import MLP
 from megatron.core.transformer.module import GraphableMegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
+from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
+from miles_megatron_plugins.true_on_policy.debug import (
+    register_activation_grad_debug,
+    register_norm_grad_debug as _register_norm_grad_debug,
+)
 from megatron.core.utils import (
     deprecate_inference_params,
     get_pg_rank,
@@ -377,6 +382,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                     f"Unknown MLP type: {type(submodules.mlp)}. Using default kwargs.",
                 )
         self.mlp = build_module(submodules.mlp, config=self.config, **additional_mlp_kwargs)
+        self.mlp.layer_number = self.layer_number
         if hasattr(self.mlp, 'set_layer_number'):
             self.mlp.set_layer_number(self.layer_number)
 
@@ -389,7 +395,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             submodules.post_mlp_layernorm,
             config=self.config,
             hidden_size=self.config.hidden_size,
-            eps=self.config.layernorm_epsilon
+            eps=self.config.layernorm_epsilon,
         )
 
         self.recompute_input_layernorm = False
@@ -527,11 +533,15 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # runners in the cuda graph manager
         kwargs.pop("dynamic_inference_decode_only", None)
         hidden_states, context = self._forward_attention(*args, **kwargs)
+        register_activation_grad_debug(
+            self, hidden_states, layer_number=self.layer_number, name="after_attention"
+        )
         output = self._forward_mlp(
             hidden_states,
             kwargs.get("inference_context", None),
             padding_mask=kwargs.get("padding_mask", None),
         )
+        register_activation_grad_debug(self, output, layer_number=self.layer_number, name="layer_output")
         return output, context
 
     def _forward_attention(
@@ -585,19 +595,46 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
-        # Residual connection.
-        residual = hidden_states
+        # Residual connection.  The SGLang path carries MLP output and residual as a
+        # pair across layer boundaries to match SGLang's LayerCommunicator flow.
+        true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
+        sglang_carried_residual = (
+            getattr(hidden_states, "_sglang_residual", None)
+            if true_on_policy_policy.use_sglang_residual_pair
+            else None
+        )
+        residual = sglang_carried_residual if sglang_carried_residual is not None else hidden_states
 
         # Optional Input Layer norm
-        if self.recompute_input_layernorm:
+        if sglang_carried_residual is not None:
+            input_layernorm_output, residual = self.input_layernorm(hidden_states, residual)
+            _register_norm_grad_debug(
+                input_layernorm_output,
+                layer_number=self.layer_number,
+                name="input_layernorm_output",
+            )
+            _register_norm_grad_debug(
+                residual, layer_number=self.layer_number, name="input_layernorm_residual_output"
+            )
+        elif self.recompute_input_layernorm:
             self.input_layernorm_checkpoint = tensor_parallel.CheckpointWithoutOutput()
             with off_interface(self.offload_attn_norm, hidden_states, "attn_norm") as hidden_states:
                 input_layernorm_output = self.input_layernorm_checkpoint.checkpoint(
                     self.input_layernorm, hidden_states
                 )
+            _register_norm_grad_debug(
+                input_layernorm_output,
+                layer_number=self.layer_number,
+                name="input_layernorm_output",
+            )
         else:
             with off_interface(self.offload_attn_norm, hidden_states, "attn_norm") as hidden_states:
                 input_layernorm_output = self.input_layernorm(hidden_states)
+            _register_norm_grad_debug(
+                input_layernorm_output,
+                layer_number=self.layer_number,
+                name="input_layernorm_output",
+            )
 
         using_fused_tp_inference_kernel = (not self.training) and (
             self.config.inference_fuse_tp_communication
@@ -643,6 +680,14 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             # The remaining residual add is already handled inside the
             # self attention module.
             hidden_states = attention_output_with_bias[0]
+        elif true_on_policy_policy.use_sglang_residual_pair:
+            attention_output, attention_output_bias = attention_output_with_bias
+            if attention_output_bias is not None:
+                attention_output = attention_output + attention_output_bias
+            hidden_states = torch.nn.functional.dropout(
+                attention_output, p=self.hidden_dropout, training=self.training
+            )
+            self._sglang_pre_mlp_residual = residual
         else:
             with self.bias_dropout_add_exec_handler():
                 hidden_states = self.self_attn_bda(self.training, self.config.bias_dropout_fusion)(
@@ -683,12 +728,17 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
         return hidden_states, context
 
-    def _forward_pre_mlp_layernorm(self, hidden_states):
+    def _forward_pre_mlp_layernorm(self, hidden_states, residual=None):
         from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
             FineGrainedActivationOffloadingInterface as off_interface,
         )
 
         if self.recompute_pre_mlp_layernorm:
+            if residual is not None:
+                raise AssertionError(
+                    "SGLang residual-pair pre-MLP layernorm is not compatible with "
+                    "selective pre_mlp_layernorm recompute."
+                )
             self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput()
             with off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm") as hidden_states:
                 pre_mlp_layernorm_output = self.pre_mlp_norm_checkpoint.checkpoint(
@@ -696,7 +746,24 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 )
         else:
             with off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm") as hidden_states:
-                pre_mlp_layernorm_output = self.pre_mlp_layernorm(hidden_states)
+                if residual is None:
+                    pre_mlp_layernorm_output = self.pre_mlp_layernorm(hidden_states)
+                    _register_norm_grad_debug(
+                        pre_mlp_layernorm_output,
+                        layer_number=self.layer_number,
+                        name="pre_mlp_layernorm_output",
+                    )
+                else:
+                    pre_mlp_layernorm_output = self.pre_mlp_layernorm(hidden_states, residual)
+                    norm_output, norm_residual = pre_mlp_layernorm_output
+                    _register_norm_grad_debug(
+                        norm_output, layer_number=self.layer_number, name="pre_mlp_layernorm_output"
+                    )
+                    _register_norm_grad_debug(
+                        norm_residual,
+                        layer_number=self.layer_number,
+                        name="pre_mlp_layernorm_residual_output",
+                    )
 
         return pre_mlp_layernorm_output
 
@@ -717,10 +784,18 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         """
 
         # Residual connection.
-        residual = hidden_states
+        residual = getattr(self, "_sglang_pre_mlp_residual", hidden_states)
+        if hasattr(self, "_sglang_pre_mlp_residual"):
+            del self._sglang_pre_mlp_residual
 
         # Optional Layer norm post the cross-attention.
-        pre_mlp_layernorm_output = self._forward_pre_mlp_layernorm(hidden_states)
+        true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
+        if true_on_policy_policy.use_sglang_residual_pair and residual is not hidden_states:
+            pre_mlp_layernorm_output, residual = self._forward_pre_mlp_layernorm(
+                hidden_states, residual
+            )
+        else:
+            pre_mlp_layernorm_output = self._forward_pre_mlp_layernorm(hidden_states)
 
         nvtx_range_push(suffix="mlp")
         # Potentially chunk the MLP computation during prefill to minimize the peak activation size
@@ -828,11 +903,19 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # TODO: could we move `bias_dropout_add_exec_handler` itself
         # inside the module provided in the `bias_dropout_add_spec` module?
         nvtx_range_push(suffix="mlp_bda")
+        true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
         if using_fused_tp_inference_kernel:
             # In inference optimized transformer layer, there is no bias and dropout
             # The remaining residual add is already handled inside the
             # MLP module.
             hidden_states = mlp_output_with_bias[0]
+        elif true_on_policy_policy.use_sglang_residual_pair:
+            mlp_output, mlp_output_bias = mlp_output_with_bias
+            if mlp_output_bias is not None:
+                mlp_output = mlp_output + mlp_output_bias
+            hidden_states = torch.nn.functional.dropout(
+                mlp_output, p=self.hidden_dropout, training=self.training
+            )
         else:
             with self.bias_dropout_add_exec_handler():
                 hidden_states = self.mlp_bda(self.training, self.config.bias_dropout_fusion)(
@@ -855,6 +938,8 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         output = make_viewless_tensor(
             inp=hidden_states, requires_grad=hidden_states.requires_grad, keep_graph=True
         )
+        if true_on_policy_policy.use_sglang_residual_pair:
+            output._sglang_residual = residual
 
         return output
 

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -398,6 +398,23 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             eps=self.config.layernorm_epsilon,
         )
 
+        # DeepSeek V4 Hyper-Connection per-layer parameters
+        if self.config.dsv4_mode:
+            hc_mult = self.config.dsv4_hc_mult
+            hc_dim = hc_mult * self.config.hidden_size
+            mix_size = (2 + hc_mult) * hc_mult
+            # HC attention parameters
+            self.hc_attn_fn = torch.nn.Parameter(torch.empty(mix_size, hc_dim, dtype=torch.float32))
+            self.hc_attn_base = torch.nn.Parameter(torch.empty(mix_size, dtype=torch.float32))
+            self.hc_attn_scale = torch.nn.Parameter(torch.empty(3, dtype=torch.float32))
+            # HC FFN parameters
+            self.hc_ffn_fn = torch.nn.Parameter(torch.empty(mix_size, hc_dim, dtype=torch.float32))
+            self.hc_ffn_base = torch.nn.Parameter(torch.empty(mix_size, dtype=torch.float32))
+            self.hc_ffn_scale = torch.nn.Parameter(torch.empty(3, dtype=torch.float32))
+            for p in [self.hc_attn_fn, self.hc_attn_base, self.hc_attn_scale,
+                       self.hc_ffn_fn, self.hc_ffn_base, self.hc_ffn_scale]:
+                p._keep_fp32 = True
+
         self.recompute_input_layernorm = False
         self.recompute_pre_mlp_layernorm = False
         self.recompute_mlp = False
@@ -532,6 +549,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # this is only used to uniquely identify decode and non-decode cuda graph
         # runners in the cuda graph manager
         kwargs.pop("dynamic_inference_decode_only", None)
+        input_ids = kwargs.pop("input_ids", None)
         hidden_states, context = self._forward_attention(*args, **kwargs)
         register_activation_grad_debug(
             self, hidden_states, layer_number=self.layer_number, name="after_attention"
@@ -540,6 +558,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             hidden_states,
             kwargs.get("inference_context", None),
             padding_mask=kwargs.get("padding_mask", None),
+            input_ids=input_ids,
         )
         register_activation_grad_debug(self, output, layer_number=self.layer_number, name="layer_output")
         return output, context
@@ -605,6 +624,14 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         )
         residual = sglang_carried_residual if sglang_carried_residual is not None else hidden_states
 
+        # HC pre for attention sublayer
+        if self.config.dsv4_mode:
+            from miles_plugins.models.deepseek_v4.ops.hyper_connection import DeepSeekV4HyperConnectionUtil
+            hc_util = DeepSeekV4HyperConnectionUtil(self.config)
+            hidden_states, hc_attn_post, hc_attn_comb = hc_util.layer_pre(
+                hidden_states, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
+            )
+
         # Optional Input Layer norm
         if sglang_carried_residual is not None:
             input_layernorm_output, residual = self.input_layernorm(hidden_states, residual)
@@ -668,31 +695,36 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 attention_output_with_bias[0]
             )
 
-        attention_output, attention_output_bias = attention_output_with_bias
-        attention_output = self.post_self_attn_layernorm(attention_output)
-        attention_output_with_bias = (attention_output, attention_output_bias)
-
-        # TODO: could we move `bias_dropout_add_exec_handler` itself
-        # inside the module provided in the `bias_dropout_add_spec` module?
         nvtx_range_push(suffix="self_attn_bda")
-        if using_fused_tp_inference_kernel:
-            # In inference optimized transformer layer, there is no bias and dropout
-            # The remaining residual add is already handled inside the
-            # self attention module.
-            hidden_states = attention_output_with_bias[0]
-        elif true_on_policy_policy.use_sglang_residual_pair:
-            attention_output, attention_output_bias = attention_output_with_bias
-            if attention_output_bias is not None:
-                attention_output = attention_output + attention_output_bias
-            hidden_states = torch.nn.functional.dropout(
-                attention_output, p=self.hidden_dropout, training=self.training
+        if self.config.dsv4_mode:
+            hidden_states = hc_util.layer_post(
+                attention_output_with_bias, residual, hc_attn_post, hc_attn_comb
             )
-            self._sglang_pre_mlp_residual = residual
         else:
-            with self.bias_dropout_add_exec_handler():
-                hidden_states = self.self_attn_bda(self.training, self.config.bias_dropout_fusion)(
-                    attention_output_with_bias, residual, self.hidden_dropout
+            attention_output, attention_output_bias = attention_output_with_bias
+            attention_output = self.post_self_attn_layernorm(attention_output)
+            attention_output_with_bias = (attention_output, attention_output_bias)
+
+            # TODO: could we move `bias_dropout_add_exec_handler` itself
+            # inside the module provided in the `bias_dropout_add_spec` module?
+            if using_fused_tp_inference_kernel:
+                # In inference optimized transformer layer, there is no bias and dropout
+                # The remaining residual add is already handled inside the
+                # self attention module.
+                hidden_states = attention_output_with_bias[0]
+            elif true_on_policy_policy.use_sglang_residual_pair:
+                attention_output, attention_output_bias = attention_output_with_bias
+                if attention_output_bias is not None:
+                    attention_output = attention_output + attention_output_bias
+                hidden_states = torch.nn.functional.dropout(
+                    attention_output, p=self.hidden_dropout, training=self.training
                 )
+                self._sglang_pre_mlp_residual = residual
+            else:
+                with self.bias_dropout_add_exec_handler():
+                    hidden_states = self.self_attn_bda(self.training, self.config.bias_dropout_fusion)(
+                        attention_output_with_bias, residual, self.hidden_dropout
+                    )
         nvtx_range_pop(suffix="self_attn_bda")
 
         # Delay the offload of the attention norm until after the self_attn_bda has been computed
@@ -767,7 +799,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
         return pre_mlp_layernorm_output
 
-    def _forward_mlp(self, hidden_states, inference_context=None, padding_mask=None):
+    def _forward_mlp(self, hidden_states, inference_context=None, padding_mask=None, input_ids=None):
         """
         Perform a forward pass through the feed-forward layer.
 
@@ -776,6 +808,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 Shape [seq_length, batch_size, hidden_size].
             inference_context: Inference context for optimizations.
             padding_mask (Tensor, optional): Padding mask for MoE routing.
+            input_ids (Tensor, optional): Input token IDs for hash routing in MoE.
                 Shape [bsz, seq_length]. True = padding (exclude), False = valid (include).
                 Only used for MoE layers to exclude padding tokens from aux loss computations.
                 The MoELayer will internally transform this to [seq_length, bsz] format.
@@ -787,6 +820,14 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         residual = getattr(self, "_sglang_pre_mlp_residual", hidden_states)
         if hasattr(self, "_sglang_pre_mlp_residual"):
             del self._sglang_pre_mlp_residual
+
+        # HC pre for MLP sublayer
+        if self.config.dsv4_mode:
+            from miles_plugins.models.deepseek_v4.ops.hyper_connection import DeepSeekV4HyperConnectionUtil
+            hc_util = DeepSeekV4HyperConnectionUtil(self.config)
+            hidden_states, hc_ffn_post, hc_ffn_comb = hc_util.layer_pre(
+                hidden_states, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base
+            )
 
         # Optional Layer norm post the cross-attention.
         true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
@@ -848,7 +889,11 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 # Set the residual for fused reduce-scatter + add + layer-norm + all-gather
                 # operation in MLP's fc2.
                 self._set_fc2_residual(residual)
-            mlp_output_with_bias = self.mlp(pre_mlp_layernorm_output, padding_mask=padding_mask)
+            mlp_output_with_bias = self.mlp(
+                pre_mlp_layernorm_output,
+                padding_mask=padding_mask,
+                **(dict(input_ids=input_ids) if self.is_moe_layer else {}),
+            )
 
         mlp_output, mlp_output_bias = mlp_output_with_bias
         mlp_output = self.post_mlp_layernorm(mlp_output)
@@ -872,15 +917,21 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                     self.pre_mlp_norm_checkpoint.discard_output_and_register_recompute(tensor)
             return list(mlp_output_with_bias) + [residual]
         else:
-            return self._forward_post_mlp(mlp_output_with_bias, residual)
+            return self._forward_post_mlp(
+                mlp_output_with_bias, residual,
+                hc_ffn_post=hc_ffn_post if self.config.dsv4_mode else None,
+                hc_ffn_comb=hc_ffn_comb if self.config.dsv4_mode else None,
+            )
 
-    def _forward_post_mlp(self, mlp_output_with_bias, residual):
+    def _forward_post_mlp(self, mlp_output_with_bias, residual, *, hc_ffn_post=None, hc_ffn_comb=None):
         """
         Perform operations after the MLP computation.
 
         Args:
             mlp_output_with_bias (Tensor): Output tensor of the MLP layer with bias.
             residual (Tensor): Residual tensor.
+            hc_ffn_post (Tensor, optional): HC post weights for DSV4 mode.
+            hc_ffn_comb (Tensor, optional): HC comb weights for DSV4 mode.
 
         Returns:
             output (Tensor): Transformed hidden states of shape [s, b, h].
@@ -904,7 +955,14 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # inside the module provided in the `bias_dropout_add_spec` module?
         nvtx_range_push(suffix="mlp_bda")
         true_on_policy_policy = resolve_true_on_policy_runtime_policy(self.config)
-        if using_fused_tp_inference_kernel:
+        if self.config.dsv4_mode:
+            # DSV4: skip bias_dropout_add; residual connection is handled by HC layer_post.
+            from miles_plugins.models.deepseek_v4.ops.hyper_connection import DeepSeekV4HyperConnectionUtil
+            hc_util = DeepSeekV4HyperConnectionUtil(self.config)
+            hidden_states = hc_util.layer_post(
+                mlp_output_with_bias, residual, hc_ffn_post, hc_ffn_comb
+            )
+        elif using_fused_tp_inference_kernel:
             # In inference optimized transformer layer, there is no bias and dropout
             # The remaining residual add is already handled inside the
             # MLP module.
@@ -922,6 +980,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                     mlp_output_with_bias, residual, self.hidden_dropout
                 )
         nvtx_range_pop(suffix="mlp_bda")
+
         # Delay the offload of the mlp norm until after the mlp_bda has been computed
         # because the residual is needed in the mlp_bda.
         if self.offload_mlp_norm:
@@ -1226,7 +1285,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 return residual, hidden_states, probs, shared_expert_output
 
             # CUDA Graph does not capture the MLP/MoE part at all.
-            output = self._forward_mlp(*cuda_graph_output)
+            output = self._forward_mlp(*cuda_graph_output, input_ids=kwargs.get("input_ids", None))
         return output, context
 
     def _get_te_cuda_graph_replay_args(self, *args, **kwargs):
@@ -1449,7 +1508,7 @@ class MoETransformerLayer(TransformerLayer):
         output = self.mlp(None, intermediate_tensors=(output, shared_expert_output))
         return self._forward_post_mlp((output, mlp_bias), residual)
 
-    def _forward_mlp(self, hidden_states, inference_context=None, padding_mask=None):
+    def _forward_mlp(self, hidden_states, inference_context=None, padding_mask=None, input_ids=None):
         """
         Orchestrates the MLP forward pass, handling partial CUDA graph execution logic.
 
@@ -1499,4 +1558,4 @@ class MoETransformerLayer(TransformerLayer):
             else:
                 return _forward_mlp_partial_cudagraphs(hidden_states, padding_mask=padding_mask)
         else:
-            return super()._forward_mlp(hidden_states, padding_mask=padding_mask)
+            return super()._forward_mlp(hidden_states, padding_mask=padding_mask, input_ids=input_ids)

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1388,6 +1388,9 @@ def core_transformer_config_from_args(args, config_class=None):
 
     kw_args['inference_sampling_seed'] = args.seed
 
+    kw_args['post_self_attn_layernorm'] = args.post_self_attn_layernorm
+    kw_args['post_mlp_layernorm'] = args.post_mlp_layernorm
+
     # handle quantization config
     # NOTE: Kitchen arguments are only added to the namespace when
     # Kitchen library is available.

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2196,6 +2196,9 @@ def _add_checkpointing_args(parser):
                        help='Do not load optimizer when loading checkpoint.')
     group.add_argument('--no-load-rng', action='store_true', default=None,
                        help='Do not load rng state when loading checkpoint.')
+    group.add_argument('--low-memory-resume', action='store_true', default=False,
+                       help='Allocate optimizer states on CPU during distributed optimizer checkpoint loading '
+                       'to prevent GPU OOM on large peak memory.')
     group.add_argument('--use-dist-ckpt', action='store_true',
                        dest='use_dist_ckpt_deprecated',
                        help='Deprecated: see --ckpt-format.')

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1634,6 +1634,8 @@ def _add_network_size_args(parser):
         "barrier_with_L1_time",
         # args uses same var with a different name
         "num_moe_experts",
+        # defined in _add_tokenizer_args, required by topk router
+        "vocab_size",
         "fp8_param",
         # incompatible defaults in dataclass
         "gradient_accumulation_fusion",
@@ -2779,6 +2781,12 @@ def _add_mla_args(parser):
                        help="Mscale all dimensions for YaRN RoPE in multi-latent attention.")
     group.add_argument('--cache-mla-latents', action='store_true', default=False,
                        help="If set caches the mla down projected latents with mla flash decode.")
+    group.add_argument('--original-max-position-embeddings', type=int, default=4096,
+                       help="Original maximum position embeddings for the original model, used by yarn.")
+    group.add_argument('--beta-fast', type=float, default=32,
+                       help="Beta fast for YaRN RoPE.")
+    group.add_argument('--beta-slow', type=float, default=1,
+                       help="Beta slow for YaRN RoPE.")
 
     return parser
 

--- a/megatron/training/tokenizer/tokenizer.py
+++ b/megatron/training/tokenizer/tokenizer.py
@@ -136,7 +136,7 @@ class _HuggingFaceTokenizer(MegatronLegacyTokenizer):
         # TODO(bnorick): download tokenizer once to lustre and use force offline to make sure all tasks read it from there
         self._tokenizer = transformers.AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path=pretrained_model_name_or_path,
-            trust_remote_code=trust_remote_code,
+            trust_remote_code=True,
             **kwargs,
         )
         self._vocab = self._tokenizer.get_vocab()

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1274,6 +1274,12 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
     # After TE2.x: Below function is an empty function and does nothing.
     correct_amax_history_if_needed(model)
 
+    # Miles allows selected parameters to opt out of Float16Module's global
+    # bf16/fp16 cast. Restore those dtypes immediately after model materialization.
+    from miles.backends.megatron_utils.fp32_param_utils import enforce_marked_param_dtypes
+
+    enforce_marked_param_dtypes(model)
+
     if wrap_with_ddp:
         if args.use_torch_fsdp2:
             assert HAVE_FSDP2, "Torch FSDP2 requires torch>=2.4.0"

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1321,6 +1321,10 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             # Set bucket_size to infinity if overlap_grad_reduce is False.
             if not ddp_config.overlap_grad_reduce:
                 ddp_config.bucket_size = None
+        ddp_extra_kwargs = {}
+        if getattr(args, 'disable_grad_buffers_cpu_backup', False):
+            ddp_extra_kwargs['disable_grad_buffers_cpu_backup'] = True
+
         # Setup stream for ddp initialization. The side-stream may be necessary for cuda graph
         #  capture support with DDP, but we sync it with the current stream to avoid races.
         ddp_stream = torch.cuda.Stream()
@@ -1337,6 +1341,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
                     # model chunks is overlapped with compute anyway.
                     disable_bucketing=(model_chunk_idx > 0)
                     or args.overlap_param_gather_with_optimizer_step,
+                    **ddp_extra_kwargs,
                 )
                 for (model_chunk_idx, model_chunk) in enumerate(model)
             ]

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1324,6 +1324,8 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         ddp_extra_kwargs = {}
         if getattr(args, 'disable_grad_buffers_cpu_backup', False):
             ddp_extra_kwargs['disable_grad_buffers_cpu_backup'] = True
+        if getattr(args, 'disable_param_buffers_cpu_backup', False):
+            ddp_extra_kwargs['disable_param_buffers_cpu_backup'] = True
 
         # Setup stream for ddp initialization. The side-stream may be necessary for cuda graph
         #  capture support with DDP, but we sync it with the current stream to avoid races.

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1274,12 +1274,6 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
     # After TE2.x: Below function is an empty function and does nothing.
     correct_amax_history_if_needed(model)
 
-    # Miles allows selected parameters to opt out of Float16Module's global
-    # bf16/fp16 cast. Restore those dtypes immediately after model materialization.
-    from miles.backends.megatron_utils.fp32_param_utils import enforce_marked_param_dtypes
-
-    enforce_marked_param_dtypes(model)
-
     if wrap_with_ddp:
         if args.use_torch_fsdp2:
             assert HAVE_FSDP2, "Torch FSDP2 requires torch>=2.4.0"

--- a/miles_megatron_plugins/true_on_policy/__init__.py
+++ b/miles_megatron_plugins/true_on_policy/__init__.py
@@ -1,0 +1,1 @@
+"""True-on-policy backend components for Megatron Core."""

--- a/miles_megatron_plugins/true_on_policy/attention_fa3.py
+++ b/miles_megatron_plugins/true_on_policy/attention_fa3.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import inspect
+import math
+import os
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.transformer_config import TransformerConfig
+from .cp_layout import SGLangUlyssesCPLayout
+from megatron.core.utils import divide
+
+try:
+    from flash_attn_interface import flash_attn_varlen_func as fa3_varlen_func
+
+    HAVE_FA3_VARLEN = True
+except ImportError:
+    try:
+        from flash_attn_3.flash_attn_interface import flash_attn_varlen_func as fa3_varlen_func
+
+        HAVE_FA3_VARLEN = True
+    except ImportError:
+        HAVE_FA3_VARLEN = False
+        fa3_varlen_func = None
+
+
+class SGLangFlashAttention(MegatronModule):
+    """SGLang-compatible FA3 attention path with packed-sequence support."""
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        layer_number: int,
+        attn_mask_type: AttnMaskType,
+        attention_type: str,
+        attention_dropout: Optional[float] = None,
+        softmax_scale: Optional[float] = None,
+        cp_comm_type: Optional[str] = None,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+    ) -> None:
+        super().__init__(config=config)
+
+        self.config = config
+        self.layer_number = max(1, layer_number)
+        self.attn_mask_type = attn_mask_type
+        self.attention_type = attention_type
+        self.current_max_attn_logits = None
+        self.cp_size = config.context_parallel_size
+        self.cp_comm_type = cp_comm_type
+
+        if self.cp_size > 1:
+            assert cp_comm_type == "a2a", (
+                "SGLangFlashAttention currently supports packed CP only with Ulysses "
+                f"(cp_comm_type='a2a'), got {cp_comm_type!r}"
+            )
+            assert pg_collection is not None and hasattr(
+                pg_collection, "cp"
+            ), "ProcessGroupCollection must provide a CP group for SGLangFlashAttention"
+            self.cp_layout = SGLangUlyssesCPLayout(pg_collection.cp, self.cp_size)
+        else:
+            self.cp_layout = None
+
+        kv_channels = config.kv_channels
+        assert kv_channels is not None, "kv_channels must be set"
+        projection_size = kv_channels * config.num_attention_heads
+        tp_world_size = pg_collection.tp.size() if pg_collection is not None else 1
+
+        self.hidden_size_per_partition = divide(projection_size, tp_world_size)
+        self.hidden_size_per_attention_head = divide(projection_size, config.num_attention_heads)
+        self.num_attention_heads_per_partition = divide(config.num_attention_heads, tp_world_size)
+        self.num_query_groups_per_partition = divide(config.num_query_groups, tp_world_size)
+
+        self.softmax_scale = (
+            1.0 / math.sqrt(self.hidden_size_per_attention_head)
+            if softmax_scale is None
+            else softmax_scale
+        )
+        if config.apply_query_key_layer_scaling:
+            self.softmax_scale /= self.layer_number
+
+        self.attention_dropout = (
+            config.attention_dropout if attention_dropout is None else attention_dropout
+        )
+
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attention_mask: Tensor,
+        attn_mask_type: AttnMaskType = None,
+        attention_bias: Tensor = None,
+        packed_seq_params: Optional[PackedSeqParams] = None,
+    ) -> Tensor:
+        del attention_mask
+
+        assert attention_bias is None, "Attention bias is not supported for SGLangFlashAttention"
+        assert (
+            attn_mask_type is None or attn_mask_type == AttnMaskType.causal
+        ), "Only causal attention is supported for SGLangFlashAttention"
+        if not HAVE_FA3_VARLEN or fa3_varlen_func is None:
+            raise ImportError("Flash Attention 3 varlen is required for SGLangFlashAttention")
+
+        is_packed = packed_seq_params is not None
+        input_ndim = query.dim()
+        head_dim_idx = -2 if is_packed and input_ndim >= 3 else 2
+        if self.num_attention_heads_per_partition // self.num_query_groups_per_partition > 1:
+            repeat_factor = (
+                self.num_attention_heads_per_partition // self.num_query_groups_per_partition
+            )
+            key = key.repeat_interleave(repeat_factor, dim=head_dim_idx)
+            value = value.repeat_interleave(repeat_factor, dim=head_dim_idx)
+
+        query = query.to(torch.bfloat16)
+        key = key.to(torch.bfloat16)
+        value = value.to(torch.bfloat16)
+
+        if is_packed:
+            if input_ndim == 3:
+                total_tokens, _, _ = query.shape
+            else:
+                total_tokens, batch_size, _, _ = query.shape
+                assert batch_size == 1, f"Packed sequences should use batch=1, got {batch_size}"
+                query = query.squeeze(1)
+                key = key.squeeze(1)
+                value = value.squeeze(1)
+
+            cu_seqlens_q = packed_seq_params.cu_seqlens_q
+            cu_seqlens_k = packed_seq_params.cu_seqlens_kv
+            max_seqlen_q = packed_seq_params.max_seqlen_q
+            max_seqlen_k = packed_seq_params.max_seqlen_kv
+            if cu_seqlens_q.dtype != torch.int32:
+                cu_seqlens_q = cu_seqlens_q.to(torch.int32)
+            if cu_seqlens_k.dtype != torch.int32:
+                cu_seqlens_k = cu_seqlens_k.to(torch.int32)
+        else:
+            seq_len, batch_size, num_heads, head_dim = query.shape
+            key_seq_len = key.shape[0]
+            query = query.transpose(0, 1).reshape(batch_size * seq_len, num_heads, head_dim)
+            key = key.transpose(0, 1).reshape(batch_size * key_seq_len, num_heads, head_dim)
+            value = value.transpose(0, 1).reshape(batch_size * key_seq_len, num_heads, head_dim)
+            cu_seqlens_q = torch.arange(
+                0, (batch_size + 1) * seq_len, seq_len, dtype=torch.int32, device=query.device
+            )
+            cu_seqlens_k = torch.arange(
+                0,
+                (batch_size + 1) * key_seq_len,
+                key_seq_len,
+                dtype=torch.int32,
+                device=query.device,
+            )
+            max_seqlen_q = seq_len
+            max_seqlen_k = key_seq_len
+
+        if self.cp_size > 1:
+            assert is_packed, "SGLang Ulysses CP currently requires packed THD inputs."
+            assert self.cp_layout is not None
+            local_tokens, local_heads, _ = query.shape
+            query = self.cp_layout.sequence_to_head_parallel(query, cu_seqlens_q)
+            key = self.cp_layout.sequence_to_head_parallel(key, cu_seqlens_k)
+            value = self.cp_layout.sequence_to_head_parallel(value, cu_seqlens_k)
+
+        sig = inspect.signature(fa3_varlen_func)
+        fa3_kwargs = {
+            "q": query,
+            "k": key,
+            "v": value,
+            "cu_seqlens_q": cu_seqlens_q,
+            "cu_seqlens_k": cu_seqlens_k,
+            "max_seqlen_q": max_seqlen_q,
+            "max_seqlen_k": max_seqlen_k,
+            "softmax_scale": self.softmax_scale,
+            "causal": True,
+        }
+        if "dropout_p" in sig.parameters:
+            fa3_kwargs["dropout_p"] = self.attention_dropout if self.training else 0.0
+        if "window_size" in sig.parameters:
+            fa3_kwargs["window_size"] = (-1, -1)
+        if "softcap" in sig.parameters:
+            fa3_kwargs["softcap"] = 0.0
+        if "return_attn_probs" in sig.parameters:
+            fa3_kwargs["return_attn_probs"] = False
+        if "return_softmax_lse" in sig.parameters:
+            fa3_kwargs["return_softmax_lse"] = False
+        if "num_splits" in sig.parameters:
+            fa3_kwargs["num_splits"] = 1
+        if (
+            "deterministic" in sig.parameters
+            and os.environ.get("MEGATRON_TRUE_ON_POLICY_FA3_DETERMINISTIC_BWD") == "1"
+        ):
+            fa3_kwargs["deterministic"] = True
+
+        output = fa3_varlen_func(**fa3_kwargs)
+        if isinstance(output, tuple):
+            output = output[0]
+
+        if self.cp_size > 1:
+            assert self.cp_layout is not None
+            output = self.cp_layout.head_to_sequence_parallel(
+                output, cu_seqlens_q, local_tokens, local_heads
+            )
+
+        if is_packed:
+            if input_ndim == 3:
+                return output.view(total_tokens, self.hidden_size_per_partition)
+            return output.view(total_tokens, 1, self.hidden_size_per_partition)
+
+        output = output.view(batch_size, seq_len, num_heads, head_dim)
+        output = output.transpose(0, 1)
+        return output.reshape(seq_len, batch_size, self.hidden_size_per_partition)
+
+
+class SGLangCoreAttention(MegatronModule):
+    """Core-attention wrapper used by the SGLang backend."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        config = kwargs.get("config")
+        if config is None and args:
+            config = args[0]
+        super().__init__(config=config)
+        self.impl = SGLangFlashAttention(*args, **kwargs)
+        self._current_max_attn_logits = getattr(self.impl, "current_max_attn_logits", None)
+
+    @property
+    def current_max_attn_logits(self):
+        return getattr(self.impl, "current_max_attn_logits", self._current_max_attn_logits)
+
+    @current_max_attn_logits.setter
+    def current_max_attn_logits(self, value):
+        self._current_max_attn_logits = value
+        if hasattr(self.impl, "current_max_attn_logits"):
+            self.impl.current_max_attn_logits = value
+
+    def forward(self, *args, **kwargs):
+        return self.impl(*args, **kwargs)

--- a/miles_megatron_plugins/true_on_policy/bias_dropout.py
+++ b/miles_megatron_plugins/true_on_policy/bias_dropout.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import torch
+
+
+def _sglang_bias_dropout_add(x_with_bias, residual, prob, training):
+    x, bias = x_with_bias
+    if bias is not None:
+        x = x + bias
+    out = torch.nn.functional.dropout(x, p=prob, training=training)
+    return out.float() + residual.float()
+
+
+def get_sglang_bias_dropout_add(training, fused):
+    del fused
+
+    def _bias_dropout_add(x_with_bias, residual, prob):
+        return _sglang_bias_dropout_add(x_with_bias, residual, prob, training)
+
+    return _bias_dropout_add

--- a/miles_megatron_plugins/true_on_policy/contracts.py
+++ b/miles_megatron_plugins/true_on_policy/contracts.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .schema import (
+    QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA,
+    TrueOnPolicyContractName,
+    TrueOnPolicyContractSchema,
+)
+
+QWEN3_DENSE_TRUE_ON_POLICY_V1 = QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA.name
+
+
+def _cp_comm_type_uses_a2a(cp_comm_type) -> bool:
+    if isinstance(cp_comm_type, str):
+        return cp_comm_type == "a2a"
+    if isinstance(cp_comm_type, list):
+        return any(item == "a2a" for item in cp_comm_type)
+    return False
+
+
+@dataclass(frozen=True)
+class MegatronTrueOnPolicyRuntimePolicy:
+    """Megatron-local behavior implied by a true-on-policy parity contract."""
+
+    contract_name: Optional[str]
+    enabled: bool
+    use_sglang_backend: bool
+    batch_invariant_mode: bool
+    disable_rope_fusion: bool
+    disable_bias_swiglu_fusion: bool
+    attention_backend: str
+    cp_layout: Optional[str]
+    cast_attention_input_to_dense_math_dtype: bool
+    cast_qk_norm_input_before_weight_mul: bool
+    cast_qk_after_rope_to_dense_math_dtype: bool
+    cast_lm_head_input_to_weight_dtype: bool
+    deterministic_row_parallel_reduce: bool
+    defer_ulysses_cp_loss_scaling_to_grad_sum: bool
+    apply_logits_contract: bool
+    use_sglang_final_norm: bool
+    use_sglang_residual_pair: bool
+    use_ulysses_cp_recompute_fallback: bool
+
+
+DEFAULT_RUNTIME_POLICY = MegatronTrueOnPolicyRuntimePolicy(
+    contract_name=None,
+    enabled=False,
+    use_sglang_backend=False,
+    batch_invariant_mode=False,
+    disable_rope_fusion=False,
+    disable_bias_swiglu_fusion=False,
+    attention_backend="default",
+    cp_layout=None,
+    cast_attention_input_to_dense_math_dtype=False,
+    cast_qk_norm_input_before_weight_mul=True,
+    cast_qk_after_rope_to_dense_math_dtype=False,
+    cast_lm_head_input_to_weight_dtype=False,
+    deterministic_row_parallel_reduce=False,
+    defer_ulysses_cp_loss_scaling_to_grad_sum=False,
+    apply_logits_contract=False,
+    use_sglang_final_norm=False,
+    use_sglang_residual_pair=False,
+    use_ulysses_cp_recompute_fallback=False,
+)
+
+
+@dataclass(frozen=True)
+class MegatronTrueOnPolicyContract:
+    """Megatron-local adapter from a shared contract schema to runtime policy."""
+
+    schema: TrueOnPolicyContractSchema
+
+    @property
+    def name(self) -> TrueOnPolicyContractName:
+        return self.schema.name
+
+    def policy_for(self, config) -> MegatronTrueOnPolicyRuntimePolicy:
+        uses_ulysses_cp = getattr(
+            config, "context_parallel_size", 1
+        ) > 1 and _cp_comm_type_uses_a2a(getattr(config, "cp_comm_type", None))
+        return MegatronTrueOnPolicyRuntimePolicy(
+            contract_name=self.name,
+            enabled=True,
+            use_sglang_backend=True,
+            batch_invariant_mode=getattr(config, "batch_invariant_mode", False),
+            disable_rope_fusion=True,
+            disable_bias_swiglu_fusion=True,
+            attention_backend="fa3_varlen",
+            cp_layout="ulysses_a2a" if uses_ulysses_cp else None,
+            cast_attention_input_to_dense_math_dtype=True,
+            cast_qk_norm_input_before_weight_mul=True,
+            cast_qk_after_rope_to_dense_math_dtype=True,
+            cast_lm_head_input_to_weight_dtype=True,
+            deterministic_row_parallel_reduce=True,
+            defer_ulysses_cp_loss_scaling_to_grad_sum=True,
+            apply_logits_contract=True,
+            use_sglang_final_norm=True,
+            use_sglang_residual_pair=True,
+            use_ulysses_cp_recompute_fallback=uses_ulysses_cp,
+        )
+
+
+QWEN3_DENSE_TRUE_ON_POLICY_CONTRACT = MegatronTrueOnPolicyContract(
+    schema=QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA
+)
+
+
+_CONTRACT_BY_NAME = {QWEN3_DENSE_TRUE_ON_POLICY_CONTRACT.name: QWEN3_DENSE_TRUE_ON_POLICY_CONTRACT}
+
+
+def get_true_on_policy_contract(contract_name: str) -> MegatronTrueOnPolicyContract:
+    try:
+        return _CONTRACT_BY_NAME[contract_name]
+    except KeyError as exc:
+        supported = ", ".join(sorted(_CONTRACT_BY_NAME))
+        raise ValueError(
+            f"Unsupported Megatron true-on-policy contract {contract_name!r}. "
+            f"Supported contracts: {supported}"
+        ) from exc
+
+
+def validate_true_on_policy_contract(contract_name: Optional[str]) -> None:
+    if contract_name is None:
+        return
+    get_true_on_policy_contract(contract_name)
+
+
+def resolve_true_on_policy_runtime_policy(config) -> MegatronTrueOnPolicyRuntimePolicy:
+    contract_name = getattr(config, "true_on_policy_contract", None)
+    if contract_name is None:
+        return DEFAULT_RUNTIME_POLICY
+
+    validate_true_on_policy_contract(contract_name)
+    return get_true_on_policy_contract(contract_name).policy_for(config)

--- a/miles_megatron_plugins/true_on_policy/cp_layout.py
+++ b/miles_megatron_plugins/true_on_policy/cp_layout.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from megatron.core.tensor_parallel.mappings import all_to_all
+
+
+class SGLangUlyssesCPLayout:
+    """Ulysses CP transforms between Megatron local sequence shards and FA3 head shards."""
+
+    def __init__(self, cp_group, cp_size: int) -> None:
+        self.cp_group = cp_group
+        self.cp_size = cp_size
+
+    def local_packed_lengths(self, cu_seqlens: Tensor, local_tokens: int) -> list[int]:
+        """Return per-packed-sequence local CP lengths from global cu_seqlens."""
+        global_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        local_lengths = []
+        for length in global_lengths:
+            assert length % self.cp_size == 0, (
+                f"Ulysses CP requires padded sequence lengths divisible by cp_size; "
+                f"got length={length}, cp_size={self.cp_size}"
+            )
+            local_lengths.append(length // self.cp_size)
+
+        assert sum(local_lengths) == local_tokens, (
+            f"Packed cu_seqlens do not match local CP shard length: "
+            f"sum(local_lengths)={sum(local_lengths)}, local_tokens={local_tokens}"
+        )
+        return local_lengths
+
+    def sequence_to_head_parallel(self, x: Tensor, cu_seqlens: Tensor) -> Tensor:
+        """Ulysses CP all-to-all: local zigzag sequence shard -> full sequence, head shard."""
+        local_tokens, num_heads, head_dim = x.shape
+        assert (
+            num_heads % self.cp_size == 0
+        ), f"num_heads={num_heads} must be divisible by cp_size={self.cp_size}"
+        local_lengths = self.local_packed_lengths(cu_seqlens, local_tokens)
+
+        x = x.reshape(local_tokens, 1, num_heads * head_dim)
+        hidden_per_rank = x.shape[-1] // self.cp_size
+        rank_ordered = torch.cat(
+            torch.split(x.reshape(local_tokens, -1), hidden_per_rank, dim=1), dim=0
+        )
+        rank_ordered = all_to_all(self.cp_group, rank_ordered)
+        rank_ordered = rank_ordered.reshape(local_tokens * self.cp_size, 1, hidden_per_rank)
+
+        per_source_offsets = []
+        offset = 0
+        for _ in range(self.cp_size):
+            per_source_offsets.append(offset)
+            offset += local_tokens
+
+        sequential = []
+        for seq_index, local_length in enumerate(local_lengths):
+            assert (
+                local_length % 2 == 0
+            ), f"Ulysses CP expects two equal zigzag chunks per rank; got local_length={local_length}"
+            chunk = local_length // 2
+            seq_offset = sum(local_lengths[:seq_index])
+
+            for source_rank in range(self.cp_size):
+                start = per_source_offsets[source_rank] + seq_offset
+                sequential.append(rank_ordered[start : start + chunk])
+            for source_rank in range(self.cp_size - 1, -1, -1):
+                start = per_source_offsets[source_rank] + seq_offset + chunk
+                sequential.append(rank_ordered[start : start + chunk])
+
+        x = torch.cat(sequential, dim=0)
+        return x.view(local_tokens * self.cp_size, num_heads // self.cp_size, head_dim)
+
+    def head_to_sequence_parallel(
+        self, x: Tensor, cu_seqlens: Tensor, local_tokens: int, num_heads: int
+    ) -> Tensor:
+        """Ulysses CP inverse all-to-all: full sequence, head shard -> local zigzag sequence shard."""
+        global_tokens, heads_per_cp_rank, head_dim = x.shape
+        assert (
+            global_tokens == local_tokens * self.cp_size
+        ), f"Unexpected Ulysses global token count: {global_tokens} vs {local_tokens * self.cp_size}"
+        assert (
+            heads_per_cp_rank * self.cp_size == num_heads
+        ), f"Unexpected Ulysses head shard: {heads_per_cp_rank} * {self.cp_size} != {num_heads}"
+        local_lengths = self.local_packed_lengths(cu_seqlens, local_tokens)
+
+        x = x.reshape(global_tokens, 1, heads_per_cp_rank * head_dim)
+        rank_ordered = [[] for _ in range(self.cp_size)]
+        seq_start = 0
+        for local_length in local_lengths:
+            chunk = local_length // 2
+            chunks = torch.split(
+                x[seq_start : seq_start + local_length * self.cp_size], chunk, dim=0
+            )
+            assert len(chunks) == 2 * self.cp_size
+            for rank in range(self.cp_size):
+                rank_ordered[rank].append(chunks[rank])
+                rank_ordered[rank].append(chunks[2 * self.cp_size - rank - 1])
+            seq_start += local_length * self.cp_size
+
+        rank_ordered = torch.cat([torch.cat(parts, dim=0) for parts in rank_ordered], dim=0)
+        rank_ordered = all_to_all(self.cp_group, rank_ordered.reshape(global_tokens, -1))
+        output = torch.cat(torch.split(rank_ordered, local_tokens, dim=0), dim=-1)
+        return output.view(local_tokens, num_heads, head_dim)

--- a/miles_megatron_plugins/true_on_policy/debug.py
+++ b/miles_megatron_plugins/true_on_policy/debug.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import torch
+from torch import Tensor
+
+
+_NORM_GRAD_DEBUG_COUNTER = 0
+
+
+def _rank() -> int:
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        return torch.distributed.get_rank()
+    return -1
+
+
+def _tensor_stats(tensor: Tensor) -> dict[str, Any]:
+    flat = tensor.detach().view(-1)
+    finite = torch.isfinite(flat)
+    nan = torch.isnan(flat)
+    inf = torch.isinf(flat)
+    stats = {
+        "shape": tuple(tensor.shape),
+        "dtype": str(tensor.dtype),
+        "numel": flat.numel(),
+        "finite": int(finite.sum().item()),
+        "nan": int(nan.sum().item()),
+        "inf": int(inf.sum().item()),
+        "max_abs_finite": None,
+        "min_finite": None,
+        "max_finite": None,
+    }
+    if stats["finite"] > 0:
+        finite_values = flat[finite].float()
+        stats.update(
+            {
+                "max_abs_finite": float(finite_values.abs().max().item()),
+                "min_finite": float(finite_values.min().item()),
+                "max_finite": float(finite_values.max().item()),
+            }
+        )
+    return stats
+
+
+def register_norm_grad_debug(tensor: Tensor, *, layer_number: int, name: str) -> None:
+    debug_dir = os.environ.get("MILES_NORM_BACKWARD_DEBUG_DIR")
+    if not debug_dir or not torch.is_tensor(tensor) or not tensor.requires_grad:
+        return
+
+    debug_all = os.environ.get("MILES_NORM_BACKWARD_DEBUG_ALL") == "1"
+    threshold = float(os.environ.get("MILES_NORM_BACKWARD_DEBUG_THRESHOLD", "1e20"))
+    debug_key = f"{layer_number}:{name}"
+
+    def _hook(grad: Tensor) -> Tensor:
+        stats = _tensor_stats(grad)
+        max_abs_finite = stats.get("max_abs_finite")
+        should_dump = debug_all or stats["nan"] or stats["inf"]
+        if max_abs_finite is not None and max_abs_finite >= threshold:
+            should_dump = True
+        if not should_dump:
+            return grad
+
+        rank = _rank()
+        if not debug_all:
+            seen = getattr(register_norm_grad_debug, "_seen", set())
+            seen_key = (rank, debug_key)
+            if seen_key in seen:
+                return grad
+            seen.add(seen_key)
+            register_norm_grad_debug._seen = seen
+
+        global _NORM_GRAD_DEBUG_COUNTER
+        counter = _NORM_GRAD_DEBUG_COUNTER
+        _NORM_GRAD_DEBUG_COUNTER += 1
+        stats.update({"rank": rank, "layer_number": layer_number, "name": name})
+        os.makedirs(debug_dir, exist_ok=True)
+        path = os.path.join(
+            debug_dir, f"rank_{rank}_layer_{layer_number}_{counter:05d}_{name}_pid_{os.getpid()}.pt"
+        )
+        torch.save(stats, path)
+        print(f"[MILES_NORM_BACKWARD_DEBUG] {stats} wrote {path}", flush=True)
+        return grad
+
+    tensor.register_hook(_hook)
+
+
+def register_activation_grad_debug(owner: object, tensor: Tensor, *, layer_number: int, name: str) -> None:
+    debug_dir = os.environ.get("MILES_ACTIVATION_GRAD_DEBUG_DIR")
+    if not debug_dir or not torch.is_tensor(tensor) or not tensor.requires_grad:
+        return
+
+    debug_key = f"{layer_number}:{name}"
+
+    def _hook(grad: Tensor) -> Tensor:
+        if torch.isfinite(grad).all().item():
+            return grad
+
+        seen = getattr(owner, "_activation_grad_debug_seen", set())
+        if debug_key in seen:
+            return grad
+        seen.add(debug_key)
+        setattr(owner, "_activation_grad_debug_seen", seen)
+
+        rank = _rank()
+        stats = _tensor_stats(grad)
+        stats.update({"rank": rank, "layer_number": layer_number, "name": name})
+        os.makedirs(debug_dir, exist_ok=True)
+        path = os.path.join(debug_dir, f"rank_{rank}_layer_{layer_number}_{name}_pid_{os.getpid()}.pt")
+        torch.save(stats, path)
+        print(f"[MILES_ACTIVATION_GRAD_DEBUG] {stats} wrote {path}", flush=True)
+        return grad
+
+    tensor.register_hook(_hook)
+
+
+def dump_param_and_grad_buffer_debug(
+    bucket_group: object,
+    *,
+    bucket_index: int,
+    grad_norm: Tensor,
+    grad_debug_dir: str,
+) -> None:
+    bucket = bucket_group.buckets[bucket_index]
+    dumped_buckets = getattr(bucket_group, "_grad_debug_dumped_buckets", set())
+    dump_key = (bucket.bucket_id, bucket_index)
+    if dump_key in dumped_buckets:
+        return
+    dumped_buckets.add(dump_key)
+    setattr(bucket_group, "_grad_debug_dumped_buckets", dumped_buckets)
+
+    rank = _rank()
+    params = []
+    for param in bucket.params_list:
+        start, end = bucket.param_to_index[param]
+        grad_slice = bucket.grad_data.view(-1)[start:end].view(param.shape)
+        params.append(
+            {
+                "name": bucket.param_to_name.get(param, "<unknown>"),
+                "shape": tuple(param.shape),
+                "requires_grad": bool(param.requires_grad),
+                "grad_slice": _tensor_stats(grad_slice),
+                "main_grad": _tensor_stats(param.main_grad)
+                if hasattr(param, "main_grad") and param.main_grad is not None
+                else None,
+            }
+        )
+
+    os.makedirs(grad_debug_dir, exist_ok=True)
+    path = os.path.join(
+        grad_debug_dir,
+        f"rank_{rank}_bucket_{bucket.bucket_id}_idx_{bucket_index}_pid_{os.getpid()}.pt",
+    )
+    torch.save(
+        {
+            "rank": rank,
+            "bucket_id": bucket.bucket_id,
+            "bucket_index": bucket_index,
+            "grad_norm": float(grad_norm.detach().float().cpu().item()),
+            "bucket_grad": _tensor_stats(bucket.grad_data),
+            "params": params,
+        },
+        path,
+    )
+    print(f"[MILES_GRAD_DEBUG] wrote nonfinite grad dump to {path}", flush=True)

--- a/miles_megatron_plugins/true_on_policy/linear.py
+++ b/miles_megatron_plugins/true_on_policy/linear.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+from .matmul import sglang_reference_matmul
+from .runtime import ensure_batch_invariant_mode_from_config
+
+
+class SGLangColumnParallelLinear(ColumnParallelLinear):
+    """Megatron local column-parallel layer with an explicit SGLang backend identity."""
+
+    backend_name = "sglang"
+
+    def _forward_impl(self, input, weight, *args, **kwargs):
+        ensure_batch_invariant_mode_from_config(self.config)
+        bias = kwargs.pop("bias", None)
+        return sglang_reference_matmul(
+            input,
+            weight,
+            bias,
+            gradient_accumulation_fusion=kwargs.pop("gradient_accumulation_fusion"),
+            allreduce_dgrad=kwargs.pop("allreduce_dgrad"),
+            sequence_parallel=kwargs.pop("sequence_parallel"),
+            grad_output_buffer=kwargs.pop("grad_output_buffer", None),
+            wgrad_deferral_limit=kwargs.pop("wgrad_deferral_limit", None),
+            tp_group=kwargs.pop("tp_group", None),
+            row_parallel=False,
+        )
+
+
+class SGLangRowParallelLinear(RowParallelLinear):
+    """Megatron local row-parallel layer with an explicit SGLang backend identity."""
+
+    backend_name = "sglang"
+
+    def _forward_impl(self, input, weight, *args, **kwargs):
+        ensure_batch_invariant_mode_from_config(self.config)
+        bias = kwargs.pop("bias", None)
+        return sglang_reference_matmul(
+            input,
+            weight,
+            bias,
+            gradient_accumulation_fusion=kwargs.pop("gradient_accumulation_fusion"),
+            allreduce_dgrad=kwargs.pop("allreduce_dgrad"),
+            sequence_parallel=kwargs.pop("sequence_parallel"),
+            grad_output_buffer=kwargs.pop("grad_output_buffer", None),
+            wgrad_deferral_limit=kwargs.pop("wgrad_deferral_limit", None),
+            tp_group=kwargs.pop("tp_group", None),
+            row_parallel=True,
+        )

--- a/miles_megatron_plugins/true_on_policy/matmul.py
+++ b/miles_megatron_plugins/true_on_policy/matmul.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+import torch
+
+from megatron.core.tensor_parallel.layers import (
+    linear_with_frozen_weight,
+    linear_with_grad_accumulation_and_async_allreduce,
+)
+
+_ROW_LINEAR_INV_BLOCK_K = 128
+
+
+def _fixed_tree_sum_tensors(tensors: Iterable[torch.Tensor]) -> torch.Tensor:
+    """Sum tensors in the same fixed pairwise order as SGLang."""
+    partials = list(tensors)
+    if not partials:
+        raise ValueError("at least one tensor is required")
+
+    while len(partials) > 1:
+        next_partials = []
+        for index in range(0, len(partials), 2):
+            if index + 1 < len(partials):
+                next_partials.append(partials[index] + partials[index + 1])
+            else:
+                next_partials.append(partials[index])
+        partials = next_partials
+
+    return partials[0]
+
+
+def _safe_group_size(group: Optional[torch.distributed.ProcessGroup]) -> int:
+    if group is not None:
+        return group.size()
+    try:
+        from megatron.core.parallel_state import get_tensor_model_parallel_world_size
+
+        return get_tensor_model_parallel_world_size()
+    except Exception:
+        return 1
+
+
+def _safe_tensor_context_parallel_size() -> int:
+    try:
+        from megatron.core.parallel_state import get_tensor_and_context_parallel_world_size
+
+        return get_tensor_and_context_parallel_world_size()
+    except Exception:
+        return _safe_group_size(None)
+
+
+def _rollout_row_parallel_partition_k(
+    input_: torch.Tensor, tp_group: Optional[torch.distributed.ProcessGroup]
+) -> int:
+    train_tp_size = _safe_group_size(tp_group)
+    rollout_tp_size = _safe_tensor_context_parallel_size()
+    global_k_size = input_.shape[-1] * train_tp_size
+    if rollout_tp_size <= 0 or global_k_size % rollout_tp_size != 0:
+        return input_.shape[-1]
+    return global_k_size // rollout_tp_size
+
+
+def _should_use_sglang_tp_invariant_row_linear(
+    input_: torch.Tensor, row_parallel: bool, tp_group: Optional[torch.distributed.ProcessGroup]
+) -> bool:
+    rollout_partition_k = _rollout_row_parallel_partition_k(input_, tp_group)
+    return (
+        row_parallel
+        and rollout_partition_k >= _ROW_LINEAR_INV_BLOCK_K
+        and rollout_partition_k % _ROW_LINEAR_INV_BLOCK_K == 0
+    )
+
+
+def _sglang_row_parallel_matmul(
+    input_: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor]
+) -> torch.Tensor:
+    """SGLang's row-linear TP-invariant matmul contract.
+
+    SGLang chunks the K dimension into 128-wide products, casts each product to
+    the input dtype, then combines those partials with a fixed binary tree.
+    Mirroring that order is required before the TP tree all-reduce can be
+    bitwise identical.
+    """
+    input_shape = input_.shape
+    input_2d = input_.reshape(-1, input_shape[-1])
+    weight_t = weight.t()
+    partials = []
+
+    for start in range(0, input_2d.shape[1], _ROW_LINEAR_INV_BLOCK_K):
+        end = min(start + _ROW_LINEAR_INV_BLOCK_K, input_2d.shape[1])
+        partials.append(input_2d[:, start:end] @ weight_t[start:end, :])
+
+    output = _fixed_tree_sum_tensors(partials).to(input_.dtype)
+    if bias is not None:
+        output = output + bias
+    return output.reshape(*input_shape[:-1], weight.shape[0])
+
+
+def _sglang_rollout_partition_row_parallel_matmul(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    *,
+    tp_group: Optional[torch.distributed.ProcessGroup],
+) -> torch.Tensor:
+    """Mirror SGLang rollout row-linear shards when train TP is smaller than rollout TP."""
+    rollout_partition_k = _rollout_row_parallel_partition_k(input_, tp_group)
+    if (
+        rollout_partition_k <= 0
+        or rollout_partition_k >= input_.shape[-1]
+        or input_.shape[-1] % rollout_partition_k != 0
+    ):
+        return _linear_reference_matmul(input_, weight, bias)
+
+    input_shape = input_.shape
+    input_2d = input_.reshape(-1, input_shape[-1])
+    weight_t = weight.t()
+    partials = []
+
+    for start in range(0, input_2d.shape[1], rollout_partition_k):
+        end = start + rollout_partition_k
+        partials.append(input_2d[:, start:end] @ weight_t[start:end, :])
+
+    output = _fixed_tree_sum_tensors(partials).to(input_.dtype)
+    if bias is not None:
+        output = output + bias
+    return output.reshape(*input_shape[:-1], weight.shape[0])
+
+
+def _linear_reference_matmul(
+    input_: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor]
+) -> torch.Tensor:
+    output = input_.reshape(-1, input_.shape[-1]) @ weight.t()
+    output = output.reshape(*input_.shape[:-1], weight.shape[0])
+    if bias is not None:
+        output = output + bias
+    return output
+
+
+def sglang_reference_matmul(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    *,
+    gradient_accumulation_fusion: bool,
+    allreduce_dgrad: bool,
+    sequence_parallel: bool,
+    grad_output_buffer: Optional[List[torch.Tensor]] = None,
+    wgrad_deferral_limit: Optional[int] = None,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    row_parallel: bool = False,
+) -> torch.Tensor:
+    """Reference TP matmul entrypoint for the SGLang-compatible backend.
+
+    PR 6 keeps Megatron on the same local numerical path by default and introduces a
+    single surface that later PRs can specialize for TP-invariant ordering. The
+    implementation intentionally delegates to the existing Megatron kernels so enabling
+    the backend flag does not yet change the training contract.
+    """
+
+    if input_.dtype != weight.dtype:
+        input_ = input_.to(weight.dtype)
+    if bias is not None and bias.dtype != weight.dtype:
+        bias = bias.to(weight.dtype)
+
+    if _should_use_sglang_tp_invariant_row_linear(input_, row_parallel, tp_group):
+        return _sglang_row_parallel_matmul(input_, weight, bias)
+    if row_parallel:
+        return _sglang_rollout_partition_row_parallel_matmul(
+            input_, weight, bias, tp_group=tp_group
+        )
+
+    if weight.requires_grad:
+        return linear_with_grad_accumulation_and_async_allreduce(
+            input=input_,
+            weight=weight,
+            bias=bias,
+            gradient_accumulation_fusion=gradient_accumulation_fusion,
+            allreduce_dgrad=allreduce_dgrad,
+            sequence_parallel=sequence_parallel,
+            grad_output_buffer=grad_output_buffer,
+            wgrad_deferral_limit=wgrad_deferral_limit or 0,
+            tp_group=tp_group,
+        )
+
+    return linear_with_frozen_weight(
+        input=input_,
+        weight=weight,
+        bias=bias,
+        gradient_accumulation_fusion=gradient_accumulation_fusion,
+        allreduce_dgrad=allreduce_dgrad,
+        sequence_parallel=sequence_parallel,
+        grad_output_buffer=grad_output_buffer,
+        wgrad_deferral_limit=wgrad_deferral_limit,
+        tp_group=tp_group,
+    )

--- a/miles_megatron_plugins/true_on_policy/norm.py
+++ b/miles_megatron_plugins/true_on_policy/norm.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+from .contracts import resolve_true_on_policy_runtime_policy
+
+
+class SGLangNorm(torch.nn.Module):
+    """Norm wrapper with Megatron-compatible parameters and SGLang backend identity."""
+
+    backend_name = "sglang"
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        hidden_size: int,
+        eps: float = 1e-5,
+        persist_layer_norm: bool = False,
+        zero_centered_gamma: bool = False,
+        normalization: str = "LayerNorm",
+        cast_x_before_out_mul: bool = True,
+        override_orig_dtype: Optional[torch.dtype] = None,
+        keep_weight_fp32: bool = True,
+    ) -> None:
+        super().__init__()
+
+        del persist_layer_norm
+        del normalization
+
+        self.config = config
+        self.hidden_size = (hidden_size,)
+        self.eps = eps
+        self.normalization = config.normalization
+        self.zero_centered_gamma = config.layernorm_zero_centered_gamma or zero_centered_gamma
+        self.cast_x_before_out_mul = cast_x_before_out_mul
+        self.override_orig_dtype = override_orig_dtype
+        self.keep_weight_fp32 = keep_weight_fp32
+
+        if self.normalization == "LayerNorm":
+            self.weight = torch.nn.Parameter(torch.empty(hidden_size))
+            self.bias = torch.nn.Parameter(torch.empty(hidden_size))
+            self.reset_parameters()
+            setattr(self.bias, "sequence_parallel", config.sequence_parallel)
+        elif self.normalization == "RMSNorm":
+            if self.zero_centered_gamma:
+                raise AssertionError("zero_centered_gamma is not supported with SGLang RMSNorm.")
+            self.weight = torch.nn.Parameter(torch.ones(hidden_size))
+            self.register_parameter("bias", None)
+        else:
+            raise Exception("Only LayerNorm and RMSNorm are currently supported")
+
+        setattr(self.weight, "sequence_parallel", config.sequence_parallel)
+
+    def reset_parameters(self) -> None:
+        if self.zero_centered_gamma:
+            torch.nn.init.zeros_(self.weight)
+        else:
+            torch.nn.init.ones_(self.weight)
+        torch.nn.init.zeros_(self.bias)
+
+    def _apply(self, fn):
+        super()._apply(fn)
+        if self.normalization == "RMSNorm" and self.keep_weight_fp32:
+            self.weight.data = self.weight.data.float()
+            if self.weight.grad is not None:
+                self.weight.grad.data = self.weight.grad.data.float()
+        return self
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+        post_residual_addition: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if self.normalization == "LayerNorm":
+            if residual is not None:
+                x = x + residual
+                if post_residual_addition is not None:
+                    x = x + post_residual_addition
+            weight = self.weight + 1 if self.zero_centered_gamma else self.weight
+            return F.layer_norm(x, self.hidden_size, weight, self.bias, self.eps)
+
+        orig_dtype = self.override_orig_dtype or x.dtype
+        x_float = x.float()
+        if residual is not None:
+            x_float = x_float + residual.float()
+            if post_residual_addition is not None:
+                x_float = x_float + post_residual_addition.float()
+            residual = x_float.to(orig_dtype)
+
+        output = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + self.eps)
+        if self.cast_x_before_out_mul:
+            output = self.weight.float() * output.to(orig_dtype)
+        else:
+            output = (output * self.weight.float()).to(orig_dtype)
+
+        if residual is None:
+            return output
+        return output, residual
+
+
+class SGLangQKRMSNorm(torch.nn.Module):
+    """Q/K RMSNorm matching the SGLang true-on-policy dense path."""
+
+    backend_name = "sglang"
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        hidden_size: int,
+        eps: float = 1e-6,
+        persist_layer_norm: bool = False,
+        zero_centered_gamma: bool = False,
+        normalization: str = "RMSNorm",
+    ) -> None:
+        super().__init__()
+
+        del persist_layer_norm
+        del zero_centered_gamma
+        del normalization
+
+        self.hidden_size = (hidden_size,)
+        self.eps = eps
+        policy = resolve_true_on_policy_runtime_policy(config)
+        self.cast_x_before_out_mul = policy.cast_qk_norm_input_before_weight_mul
+        self.weight = torch.nn.Parameter(torch.ones(hidden_size, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not x.is_contiguous():
+            x = x.contiguous()
+
+        orig_dtype = x.dtype
+        x_float = x.to(torch.float32)
+        x_float = x_float * torch.rsqrt(x_float.pow(2).mean(dim=-1, keepdim=True) + self.eps)
+
+        if self.cast_x_before_out_mul:
+            return self.weight.float() * x_float.to(orig_dtype)
+        return (x_float * self.weight.float()).to(orig_dtype)
+
+
+class SGLangFinalRMSNorm(torch.nn.Module):
+    """Final block RMSNorm matching the SGLang dense path."""
+
+    backend_name = "sglang"
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        hidden_size: int,
+        eps: float = 1e-6,
+        persist_layer_norm: bool = False,
+        zero_centered_gamma: bool = False,
+        normalization: str = "RMSNorm",
+    ) -> None:
+        super().__init__()
+
+        del config
+        del persist_layer_norm
+        del zero_centered_gamma
+        del normalization
+
+        self.hidden_size = (hidden_size,)
+        self.eps = eps
+        self.weight = torch.nn.Parameter(torch.ones(hidden_size, dtype=torch.float32))
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+        post_residual_addition: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if not x.is_contiguous():
+            x = x.contiguous()
+
+        orig_dtype = x.dtype
+        if residual is not None:
+            x = x + residual
+            if post_residual_addition is not None:
+                x = x + post_residual_addition
+            residual = x.clone()
+
+        x_float = x.to(torch.float32)
+        x_float = x_float * torch.rsqrt(x_float.pow(2).mean(dim=-1, keepdim=True) + self.eps)
+        output = self.weight * x_float.to(orig_dtype)
+
+        if residual is not None:
+            return output, residual
+        return output

--- a/miles_megatron_plugins/true_on_policy/provider.py
+++ b/miles_megatron_plugins/true_on_policy/provider.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import warnings
+from typing import Optional, Tuple
+
+import torch
+
+from megatron.core.models.backends import BackendSpecProvider
+from megatron.core.transformer.mlp import MLPSubmodules
+from megatron.core.transformer.moe.experts import GroupedMLP, SequentialMLP
+from megatron.core.transformer.spec_utils import ModuleSpec
+from .attention_fa3 import SGLangCoreAttention
+from .linear import SGLangColumnParallelLinear, SGLangRowParallelLinear
+from .norm import SGLangNorm, SGLangQKRMSNorm
+
+
+class SGLangSpecProvider(BackendSpecProvider):
+    """Backend provider for the correctness-first SGLang-compatible Megatron surface."""
+
+    def column_parallel_linear(self) -> type:
+        return SGLangColumnParallelLinear
+
+    def row_parallel_linear(self) -> type:
+        return SGLangRowParallelLinear
+
+    def fuse_layernorm_and_linear(self) -> bool:
+        return False
+
+    def column_parallel_layer_norm_linear(self) -> Optional[type]:
+        return None
+
+    def layer_norm(self, rms_norm: bool = False, for_qk: bool = False):
+        if for_qk:
+            return SGLangQKRMSNorm if rms_norm else SGLangNorm
+        return ModuleSpec(
+            module=SGLangNorm,
+            params={
+                "cast_x_before_out_mul": True,
+                "override_orig_dtype": torch.float32,
+                "keep_weight_fp32": True,
+            },
+        )
+
+    def core_attention(self) -> type:
+        return SGLangCoreAttention
+
+    def grouped_mlp_modules(
+        self, moe_use_grouped_gemm: bool, moe_use_legacy_grouped_gemm: bool
+    ) -> Tuple[type, Optional[MLPSubmodules]]:
+        del moe_use_legacy_grouped_gemm
+
+        if moe_use_grouped_gemm:
+            warnings.warn(
+                "SGLang backend falls back to Megatron's existing GroupedMLP surface "
+                "until the deterministic MoE backend is introduced."
+            )
+            return GroupedMLP, None
+
+        return SequentialMLP, MLPSubmodules(
+            linear_fc1=SGLangColumnParallelLinear, linear_fc2=SGLangRowParallelLinear
+        )
+
+    def activation_func(self) -> type:
+        return None

--- a/miles_megatron_plugins/true_on_policy/rope.py
+++ b/miles_megatron_plugins/true_on_policy/rope.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+_USE_SGLANG_ROPE = False
+
+
+def enable_sglang_rope() -> None:
+    """Enable the SGLang-compatible RoPE path used by dense true-on-policy."""
+
+    global _USE_SGLANG_ROPE
+    _USE_SGLANG_ROPE = True
+
+
+def disable_sglang_rope() -> None:
+    global _USE_SGLANG_ROPE
+    _USE_SGLANG_ROPE = False
+
+
+def is_sglang_rope_enabled() -> bool:
+    return _USE_SGLANG_ROPE
+
+
+def sglang_apply_rotary_pos_emb(
+    x: Tensor, cos: Tensor, sin: Tensor, is_neox_style: bool = True
+) -> Tensor:
+    if cos.dim() == 2:
+        cos = cos.unsqueeze(-2)
+        sin = sin.unsqueeze(-2)
+
+    orig_dtype = x.dtype
+    x = x.float()
+    cos = cos.float()
+    sin = sin.float()
+
+    rotary_dim = cos.shape[-1] * 2
+    if rotary_dim < x.shape[-1]:
+        x_rot = x[..., :rotary_dim]
+        x_pass = x[..., rotary_dim:]
+        x_rot = sglang_apply_rotary_pos_emb(x_rot, cos, sin, is_neox_style)
+        return torch.cat((x_rot, x_pass), dim=-1).to(orig_dtype)
+
+    if is_neox_style:
+        x1, x2 = torch.chunk(x, 2, dim=-1)
+    else:
+        x1 = x[..., ::2]
+        x2 = x[..., 1::2]
+
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+
+    if is_neox_style:
+        return torch.cat((o1, o2), dim=-1).to(orig_dtype)
+
+    return torch.stack((o1, o2), dim=-1).flatten(-2).to(orig_dtype)
+
+
+def sglang_apply_rotary_pos_emb_with_freqs(
+    x: Tensor, freqs: Tensor, config: TransformerConfig, layer_number: Optional[int] = None
+) -> Tensor:
+    del layer_number
+
+    x_seq_len = x.shape[0]
+    freqs_seq_len = freqs.shape[0]
+
+    freqs_flat = freqs.squeeze(1).squeeze(1)
+    head_dim = x.shape[-1]
+    raw_angles = freqs_flat[..., : head_dim // 2]
+    cos = torch.cos(raw_angles)
+    sin = torch.sin(raw_angles)
+    is_neox_style = not getattr(config, "rotary_interleaved", False)
+
+    if x_seq_len == freqs_seq_len:
+        return sglang_apply_rotary_pos_emb(x, cos, sin, is_neox_style)
+    if freqs_seq_len < x_seq_len:
+        x_valid = x[:freqs_seq_len]
+        x_valid = sglang_apply_rotary_pos_emb(x_valid, cos, sin, is_neox_style)
+        return torch.cat([x_valid, x[freqs_seq_len:]], dim=0)
+
+    cos = cos[:x_seq_len]
+    sin = sin[:x_seq_len]
+    return sglang_apply_rotary_pos_emb(x, cos, sin, is_neox_style)

--- a/miles_megatron_plugins/true_on_policy/runtime.py
+++ b/miles_megatron_plugins/true_on_policy/runtime.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+
+import torch
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def enable_sglang_batch_invariant_mode() -> None:
+    """Enable deterministic runtime knobs expected by the SGLang backend."""
+
+    from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+        enable_batch_invariant_mode,
+        is_batch_invariant_mode_enabled,
+    )
+
+    if not is_batch_invariant_mode_enabled():
+        enable_batch_invariant_mode()
+
+    torch.use_deterministic_algorithms(True)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+    os.environ["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] = "0"
+
+
+def ensure_batch_invariant_mode_from_config(config: TransformerConfig) -> None:
+    if not getattr(config, "batch_invariant_mode", False):
+        return
+
+    from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+        enable_batch_invariant_mode,
+        is_batch_invariant_mode_enabled,
+    )
+
+    if not is_batch_invariant_mode_enabled():
+        enable_batch_invariant_mode()

--- a/miles_megatron_plugins/true_on_policy/schema.py
+++ b/miles_megatron_plugins/true_on_policy/schema.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+TrueOnPolicyContractName = Literal["qwen3_dense_true_on_policy_v1"]
+ModelFamily = Literal["qwen3_dense", "qwen3_moe", "qwen3_next"]
+KernelContract = Literal["qwen3_dense_sglang_math"]
+LogprobContract = Literal["sglang_prefill"]
+
+
+@dataclass(frozen=True)
+class TrueOnPolicyContractSchema:
+    """Declarative cross-repo identity for a true-on-policy parity contract."""
+
+    name: TrueOnPolicyContractName
+    model_family: ModelFamily
+    required_kernel_contracts: tuple[KernelContract, ...]
+    logprob_contract: LogprobContract
+    sglang_attention_backend: str
+    fsdp_attention_implementation: str
+    disable_megatron_sequence_parallel: bool
+
+
+QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
+    name="qwen3_dense_true_on_policy_v1",
+    model_family="qwen3_dense",
+    required_kernel_contracts=("qwen3_dense_sglang_math",),
+    logprob_contract="sglang_prefill",
+    sglang_attention_backend="fa3",
+    fsdp_attention_implementation="flash_attention_3",
+    disable_megatron_sequence_parallel=True,
+)

--- a/miles_megatron_plugins/true_on_policy/sglang_backend.py
+++ b/miles_megatron_plugins/true_on_policy/sglang_backend.py
@@ -1,0 +1,59 @@
+"""Compatibility facade for the Megatron true-on-policy SGLang backend."""
+
+from .attention_fa3 import (
+    HAVE_FA3_VARLEN,
+    SGLangCoreAttention,
+    SGLangFlashAttention,
+    fa3_varlen_func,
+)
+from .bias_dropout import (
+    _sglang_bias_dropout_add,
+    get_sglang_bias_dropout_add,
+)
+from .contracts import (
+    QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    MegatronTrueOnPolicyRuntimePolicy,
+    resolve_true_on_policy_runtime_policy,
+)
+from .cp_layout import SGLangUlyssesCPLayout
+from .linear import SGLangColumnParallelLinear, SGLangRowParallelLinear
+from .norm import SGLangFinalRMSNorm, SGLangNorm, SGLangQKRMSNorm
+from .provider import SGLangSpecProvider
+from .rope import (
+    disable_sglang_rope,
+    enable_sglang_rope,
+    is_sglang_rope_enabled,
+    sglang_apply_rotary_pos_emb,
+    sglang_apply_rotary_pos_emb_with_freqs,
+)
+from .runtime import (
+    enable_sglang_batch_invariant_mode,
+    ensure_batch_invariant_mode_from_config,
+)
+
+_ensure_batch_invariant_mode_from_config = ensure_batch_invariant_mode_from_config
+
+__all__ = [
+    "HAVE_FA3_VARLEN",
+    "QWEN3_DENSE_TRUE_ON_POLICY_V1",
+    "MegatronTrueOnPolicyRuntimePolicy",
+    "SGLangColumnParallelLinear",
+    "SGLangCoreAttention",
+    "SGLangFinalRMSNorm",
+    "SGLangFlashAttention",
+    "SGLangNorm",
+    "SGLangQKRMSNorm",
+    "SGLangRowParallelLinear",
+    "SGLangSpecProvider",
+    "SGLangUlyssesCPLayout",
+    "_sglang_bias_dropout_add",
+    "disable_sglang_rope",
+    "enable_sglang_batch_invariant_mode",
+    "enable_sglang_rope",
+    "fa3_varlen_func",
+    "get_sglang_bias_dropout_add",
+    "is_sglang_rope_enabled",
+    "resolve_true_on_policy_runtime_policy",
+    "sglang_apply_rotary_pos_emb",
+    "sglang_apply_rotary_pos_emb_with_freqs",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,19 @@ build-backend = "setuptools.build_meta"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = [
-    "megatron.core",
-    "megatron.core.*",
-    "miles_megatron_plugins",
-    "miles_megatron_plugins.*",
-]
+# Expose every `megatron.*` sub-package so callers (e.g. the miles training
+# runner) can `pip install -e .` this checkout and freely import from
+# `megatron.training`, `megatron.legacy`, `megatron.rl`, etc. without an
+# explicit PYTHONPATH override. (megatron.training.initialize imports from
+# megatron.legacy at module load, so any narrower include list breaks
+# transitively.)
+#
+# `namespaces = true` is required because `megatron`, `megatron.legacy`, and
+# several sub-packages are namespace packages (no `__init__.py`). Without
+# this, find_packages skips them and the editable install only works via the
+# side-effect that pip adds the project root to sys.path.
+include = ["megatron*", "miles_megatron_plugins", "miles_megatron_plugins.*"]
+namespaces = true
 
 [tool.setuptools.dynamic]
 version = { attr = "megatron.core.package_info.__version__" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,12 @@ build-backend = "setuptools.build_meta"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["megatron.core", "megatron.core.*"]
+include = [
+    "megatron.core",
+    "megatron.core.*",
+    "miles_megatron_plugins",
+    "miles_megatron_plugins.*",
+]
 
 [tool.setuptools.dynamic]
 version = { attr = "megatron.core.package_info.__version__" }
@@ -187,7 +192,7 @@ emerging_optimizers = { git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizer
 profile = "black"                                                          # black-compatible
 line_length = 100                                                          # should match black parameters
 py_version = 310                                                           # python 3.8 as a target version
-known_first_party = ["megatron"]                                           # FIRSTPARTY section
+known_first_party = ["megatron", "miles_megatron_plugins"]                 # FIRSTPARTY section
 known_third_party = ["transformer_engine"]                                 # THIRDPARTY section
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
 default_section = "THIRDPARTY"

--- a/tests/unit_tests/extension/test_sglang_extension.py
+++ b/tests/unit_tests/extension/test_sglang_extension.py
@@ -1,0 +1,751 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+from contextlib import contextmanager
+
+import pytest
+import torch
+
+import megatron.core.parallel_state as parallel_state
+from miles_megatron_plugins.true_on_policy.sglang_backend import (
+    QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    MegatronTrueOnPolicyRuntimePolicy,
+    SGLangColumnParallelLinear,
+    SGLangCoreAttention,
+    SGLangFinalRMSNorm,
+    SGLangNorm,
+    SGLangQKRMSNorm,
+    SGLangRowParallelLinear,
+    SGLangSpecProvider,
+    _ensure_batch_invariant_mode_from_config,
+    disable_sglang_rope,
+    get_sglang_bias_dropout_add,
+    is_sglang_rope_enabled,
+    resolve_true_on_policy_runtime_policy,
+)
+from miles_megatron_plugins.true_on_policy.contracts import get_true_on_policy_contract
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_layer_specs
+from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+from megatron.core.tensor_parallel.layers import linear_with_grad_accumulation_and_async_allreduce
+from miles_megatron_plugins.true_on_policy.matmul import _sglang_row_parallel_matmul, sglang_reference_matmul
+from megatron.core.models.common.embeddings.rope_utils import apply_rotary_pos_emb
+from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
+    matmul_persistent,
+    set_batch_invariant_mode,
+)
+from megatron.core.transformer.enums import AttnBackend
+from megatron.core.transformer.attention import _sglang_cast_dense_tensor_math_input
+from megatron.core.transformer.linear_cross_entropy import LinearCrossEntropyModule
+from megatron.core.transformer.multi_token_prediction import get_mtp_layer_spec_for_backend
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.transformer_block import _get_block_submodules
+from megatron.core.transformer.torch_norm import WrappedTorchNorm
+from tests.unit_tests.test_utilities import Utils
+
+
+def _make_config(**overrides) -> TransformerConfig:
+    config_kwargs = {
+        "num_layers": 1,
+        "hidden_size": 16,
+        "num_attention_heads": 4,
+        "ffn_hidden_size": 32,
+        "normalization": "RMSNorm",
+        "use_cpu_initialization": True,
+        "perform_initialization": False,
+        "tensor_model_parallel_size": 1,
+        "pipeline_model_parallel_size": 1,
+        "context_parallel_size": 1,
+        "expert_model_parallel_size": 1,
+        "transformer_impl": "local",
+    }
+    config_kwargs.update(overrides)
+    return TransformerConfig(**config_kwargs)
+
+
+class _FakeCPGroup:
+    def __init__(self, size: int, rank: int):
+        self._size = size
+        self._rank = rank
+
+    def size(self):
+        return self._size
+
+    def rank(self):
+        return self._rank
+
+
+@contextmanager
+def _fake_tp_init():
+    parallel_state.destroy_model_parallel()
+    Utils.fake_initialize_model_parallel(tensor_model_parallel_size=1)
+    try:
+        yield
+    finally:
+        parallel_state.destroy_model_parallel()
+
+
+def _parse_training_args(monkeypatch, *argv):
+    from megatron.training.arguments import parse_args
+
+    monkeypatch.setattr(sys, "argv", ["test_sglang_extension.py", *argv])
+    return parse_args()
+
+
+def test_sglang_extension_imports():
+    assert SGLangColumnParallelLinear.backend_name == "sglang"
+    assert SGLangRowParallelLinear.backend_name == "sglang"
+    assert SGLangNorm.backend_name == "sglang"
+    assert callable(sglang_reference_matmul)
+    assert MegatronTrueOnPolicyRuntimePolicy.__name__ == "MegatronTrueOnPolicyRuntimePolicy"
+
+
+def test_legacy_sglang_backend_imports_match_true_on_policy_namespace():
+    from megatron.core.extensions import sglang as legacy_backend
+    from megatron.core.tensor_parallel import matmul_tp_inv as legacy_matmul
+    from miles_megatron_plugins.true_on_policy import (
+        attention_fa3,
+        bias_dropout,
+        cp_layout,
+        linear,
+        norm,
+        provider,
+        rope,
+        runtime,
+    )
+    from miles_megatron_plugins.true_on_policy import matmul, sglang_backend
+
+    assert legacy_backend.SGLangNorm is sglang_backend.SGLangNorm
+    assert legacy_backend.SGLangRowParallelLinear is sglang_backend.SGLangRowParallelLinear
+    assert sglang_backend.SGLangColumnParallelLinear is linear.SGLangColumnParallelLinear
+    assert sglang_backend.SGLangCoreAttention is attention_fa3.SGLangCoreAttention
+    assert sglang_backend.SGLangUlyssesCPLayout is cp_layout.SGLangUlyssesCPLayout
+    assert sglang_backend.SGLangNorm is norm.SGLangNorm
+    assert sglang_backend.SGLangSpecProvider is provider.SGLangSpecProvider
+    assert sglang_backend.get_sglang_bias_dropout_add is bias_dropout.get_sglang_bias_dropout_add
+    assert (
+        sglang_backend.enable_sglang_batch_invariant_mode
+        is runtime.enable_sglang_batch_invariant_mode
+    )
+    assert sglang_backend.sglang_apply_rotary_pos_emb is rope.sglang_apply_rotary_pos_emb
+    assert (
+        sglang_backend.resolve_true_on_policy_runtime_policy
+        is resolve_true_on_policy_runtime_policy
+    )
+    assert legacy_matmul.sglang_reference_matmul is matmul.sglang_reference_matmul
+
+
+def test_true_on_policy_contract_arg_parsing(monkeypatch):
+    field_names = {field.name for field in dataclasses.fields(TransformerConfig)}
+    assert "use_sglang" not in field_names
+    assert "true_on_policy_contract" in field_names
+
+    args = _parse_training_args(
+        monkeypatch, "--true-on-policy-contract", QWEN3_DENSE_TRUE_ON_POLICY_V1
+    )
+
+    assert args.true_on_policy_contract == QWEN3_DENSE_TRUE_ON_POLICY_V1
+
+
+def test_true_on_policy_contract_resolves_megatron_runtime_policy():
+    config = _make_config(
+        batch_invariant_mode=True,
+        context_parallel_size=4,
+        cp_comm_type="a2a",
+        attention_backend=AttnBackend.flash,
+        true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    )
+
+    policy = resolve_true_on_policy_runtime_policy(config)
+
+    assert policy.contract_name == QWEN3_DENSE_TRUE_ON_POLICY_V1
+    assert policy.use_sglang_backend
+    assert policy.batch_invariant_mode
+    assert policy.attention_backend == "fa3_varlen"
+    assert policy.cp_layout == "ulysses_a2a"
+    assert policy.use_ulysses_cp_recompute_fallback
+
+
+def test_contract_object_owns_megatron_runtime_policy_values():
+    contract = get_true_on_policy_contract(QWEN3_DENSE_TRUE_ON_POLICY_V1)
+    config = _make_config(
+        batch_invariant_mode=True,
+        attention_backend=AttnBackend.flash,
+        true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    )
+
+    policy = contract.policy_for(config)
+
+    assert contract.schema.name == QWEN3_DENSE_TRUE_ON_POLICY_V1
+    assert contract.schema.model_family == "qwen3_dense"
+    assert policy.contract_name == QWEN3_DENSE_TRUE_ON_POLICY_V1
+    assert policy.enabled
+    assert policy.use_sglang_backend
+    assert policy.batch_invariant_mode
+    assert policy.disable_rope_fusion
+    assert policy.disable_bias_swiglu_fusion
+    assert policy.attention_backend == "fa3_varlen"
+    assert policy.cast_attention_input_to_dense_math_dtype
+    assert policy.cast_lm_head_input_to_weight_dtype
+    assert policy.cast_qk_after_rope_to_dense_math_dtype
+    assert policy.deterministic_row_parallel_reduce
+    assert policy.defer_ulysses_cp_loss_scaling_to_grad_sum
+    assert policy.apply_logits_contract
+    assert policy.use_sglang_final_norm
+    assert policy.use_sglang_residual_pair
+    assert not policy.use_ulysses_cp_recompute_fallback
+
+
+def test_qwen3_dense_contract_only_marks_ulysses_a2a_as_cp_layout():
+    contract = get_true_on_policy_contract(QWEN3_DENSE_TRUE_ON_POLICY_V1)
+
+    policy = contract.policy_for(
+        _make_config(
+            context_parallel_size=4,
+            cp_comm_type="all_gather",
+            true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+        )
+    )
+
+    assert policy.cp_layout is None
+    assert not policy.use_ulysses_cp_recompute_fallback
+
+
+def test_missing_true_on_policy_contract_uses_default_policy():
+    config = _make_config()
+
+    policy = resolve_true_on_policy_runtime_policy(config)
+
+    assert policy.contract_name is None
+    assert not policy.enabled
+
+
+def test_invalid_true_on_policy_contract_is_rejected_by_config():
+    with pytest.raises(ValueError, match="Unsupported Megatron true-on-policy contract"):
+        _make_config(true_on_policy_contract="unknown_contract")
+
+
+def test_default_backend_selection_is_unchanged():
+    config = _make_config()
+
+    layer_spec = get_gpt_decoder_layer_specs(
+        config, use_transformer_engine=False, normalization=config.normalization
+    )[0]
+
+    assert layer_spec.submodules.input_layernorm is WrappedTorchNorm
+    assert layer_spec.submodules.self_attention.submodules.linear_qkv is ColumnParallelLinear
+    assert layer_spec.submodules.self_attention.submodules.linear_proj is RowParallelLinear
+
+
+def test_true_on_policy_contract_selects_sglang_backend():
+    disable_sglang_rope()
+    config = _make_config(true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1, qk_layernorm=True)
+
+    layer_spec = get_gpt_decoder_layer_specs(
+        config, use_transformer_engine=False, normalization=config.normalization
+    )[0]
+
+    assert is_sglang_rope_enabled()
+    assert isinstance(layer_spec.submodules.input_layernorm, ModuleSpec)
+    assert layer_spec.submodules.input_layernorm.module is SGLangNorm
+    assert layer_spec.submodules.input_layernorm.params["override_orig_dtype"] is torch.float32
+    assert layer_spec.submodules.self_attn_bda is get_sglang_bias_dropout_add
+    assert layer_spec.submodules.self_attention.submodules.linear_qkv is SGLangColumnParallelLinear
+    assert layer_spec.submodules.self_attention.submodules.core_attention is SGLangCoreAttention
+    assert layer_spec.submodules.self_attention.submodules.q_layernorm is SGLangQKRMSNorm
+    assert layer_spec.submodules.self_attention.submodules.linear_proj is SGLangRowParallelLinear
+    assert layer_spec.submodules.mlp_bda is get_sglang_bias_dropout_add
+
+
+def test_true_on_policy_contract_layer_spec_selects_sglang_final_norm():
+    config = _make_config(true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1)
+    layer_spec = get_gpt_decoder_layer_specs(
+        config, use_transformer_engine=False, normalization=config.normalization
+    )[0]
+
+    block_submodules = _get_block_submodules(config, layer_spec, pp_rank=0)
+
+    assert block_submodules.layer_norm is SGLangFinalRMSNorm
+
+
+def test_transformer_config_rejects_incompatible_true_on_policy_backend():
+    with pytest.raises(
+        AssertionError, match="true_on_policy_contract currently requires transformer_impl='local'"
+    ):
+        _make_config(
+            true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+            transformer_impl="transformer_engine",
+        )
+
+
+def test_transformer_config_rejects_true_on_policy_with_kitchen():
+    with pytest.raises(
+        AssertionError, match="true_on_policy_contract is not compatible with use_kitchen"
+    ):
+        _make_config(true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1, use_kitchen=True)
+
+
+def test_sglang_config_allows_ulysses_context_parallel():
+    config = _make_config(
+        true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+        batch_invariant_mode=True,
+        attention_backend=AttnBackend.flash,
+        tensor_model_parallel_size=1,
+        context_parallel_size=2,
+        cp_comm_type="a2a",
+    )
+
+    assert config.cp_comm_type == "a2a"
+
+
+def test_ulysses_rope_uses_cp_positions_for_local_sequence_shards():
+    config = _make_config(
+        true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+        context_parallel_size=2,
+        cp_comm_type="a2a",
+    )
+    local_t = torch.randn(4, 2, 4)
+    cu_seqlens = torch.tensor([0, 8], dtype=torch.int32)
+    freqs = torch.randn(8, 1, 1, 4)
+    cp_group = _FakeCPGroup(size=2, rank=1)
+
+    actual = apply_rotary_pos_emb(
+        local_t, freqs, config=config, cu_seqlens=cu_seqlens, cp_group=cp_group, ulysses_cp=True
+    )
+    expected = apply_rotary_pos_emb(
+        local_t, freqs, config=config, cu_seqlens=cu_seqlens, cp_group=cp_group, ulysses_cp=False
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_ulysses_rope_keeps_unsplit_positions_for_full_sequence_layout():
+    config = _make_config(
+        true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+        context_parallel_size=2,
+        cp_comm_type="a2a",
+    )
+    full_t = torch.randn(8, 2, 4)
+    cu_seqlens = torch.tensor([0, 8], dtype=torch.int32)
+    freqs = torch.randn(8, 1, 1, 4)
+
+    actual = apply_rotary_pos_emb(
+        full_t,
+        freqs,
+        config=config,
+        cu_seqlens=cu_seqlens,
+        cp_group=_FakeCPGroup(size=2, rank=1),
+        ulysses_cp=True,
+    )
+    expected = apply_rotary_pos_emb(
+        full_t,
+        freqs,
+        config=config,
+        cu_seqlens=cu_seqlens,
+        cp_group=_FakeCPGroup(size=1, rank=0),
+        ulysses_cp=False,
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_local_attention_still_rejects_ulysses_context_parallel_without_true_on_policy():
+    with pytest.raises(ValueError, match="only supports all_gather"):
+        _make_config(tensor_model_parallel_size=1, context_parallel_size=2, cp_comm_type="a2a")
+
+
+def test_sglang_reference_matmul_matches_torch_linear():
+    input_ = torch.randn(2, 3, 4)
+    weight = torch.randn(5, 4)
+    bias = torch.randn(5)
+
+    actual = sglang_reference_matmul(
+        input_,
+        weight,
+        bias,
+        gradient_accumulation_fusion=False,
+        allreduce_dgrad=False,
+        sequence_parallel=False,
+    )
+    expected = torch.nn.functional.linear(input_, weight, bias)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_reference_matmul_matches_sglang_mixed_dtype_contract():
+    input_ = torch.randn(2, 3, 4)
+    weight = torch.randn(5, 4).to(torch.bfloat16)
+    bias = torch.randn(5).to(torch.float32)
+
+    actual = sglang_reference_matmul(
+        input_,
+        weight,
+        bias,
+        gradient_accumulation_fusion=False,
+        allreduce_dgrad=False,
+        sequence_parallel=False,
+    )
+    expected = torch.matmul(input_.to(weight.dtype), weight.t()) + bias.to(weight.dtype)
+
+    assert actual.dtype == torch.bfloat16
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_row_parallel_matmul_uses_fixed_k_block_order():
+    input_ = torch.randn(2, 3, 256)
+    weight = torch.randn(5, 256)
+    bias = torch.randn(5)
+
+    actual = sglang_reference_matmul(
+        input_,
+        weight,
+        bias,
+        gradient_accumulation_fusion=False,
+        allreduce_dgrad=False,
+        sequence_parallel=False,
+        row_parallel=True,
+    )
+    expected = _sglang_row_parallel_matmul(input_, weight, bias)
+
+    assert torch.equal(actual, expected)
+
+
+def test_sglang_column_matmul_keeps_default_linear_path_for_same_k_size():
+    input_ = torch.randn(2, 3, 256)
+    weight = torch.randn(5, 256)
+    bias = torch.randn(5)
+
+    actual = sglang_reference_matmul(
+        input_,
+        weight,
+        bias,
+        gradient_accumulation_fusion=False,
+        allreduce_dgrad=False,
+        sequence_parallel=False,
+        row_parallel=False,
+    )
+    expected = torch.nn.functional.linear(input_, weight, bias)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_backend_enables_batch_invariant_mode_from_config(monkeypatch):
+    from megatron.core.transformer.custom_layers import batch_invariant_kernels
+
+    calls = []
+    config = _make_config(
+        true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+        batch_invariant_mode=True,
+        attention_backend=AttnBackend.flash,
+    )
+
+    monkeypatch.setattr(batch_invariant_kernels, "is_batch_invariant_mode_enabled", lambda: False)
+    monkeypatch.setattr(
+        batch_invariant_kernels, "enable_batch_invariant_mode", lambda: calls.append(None)
+    )
+
+    _ensure_batch_invariant_mode_from_config(config)
+
+    assert calls == [None]
+
+
+def test_sglang_backend_leaves_batch_invariant_mode_disabled(monkeypatch):
+    from megatron.core.transformer.custom_layers import batch_invariant_kernels
+
+    calls = []
+    config = _make_config(
+        true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1, batch_invariant_mode=False
+    )
+
+    monkeypatch.setattr(batch_invariant_kernels, "is_batch_invariant_mode_enabled", lambda: False)
+    monkeypatch.setattr(
+        batch_invariant_kernels, "enable_batch_invariant_mode", lambda: calls.append(None)
+    )
+
+    _ensure_batch_invariant_mode_from_config(config)
+
+    assert calls == []
+
+
+def test_sglang_dense_tensor_math_cast_matches_qwen3_contract():
+    input_ = torch.randn(2, 3, 4, dtype=torch.float32)
+
+    actual = _sglang_cast_dense_tensor_math_input(input_)
+
+    assert actual.dtype == torch.bfloat16
+    torch.testing.assert_close(actual, input_.to(torch.bfloat16))
+
+
+def test_sglang_dense_tensor_math_cast_preserves_bfloat16_tensor():
+    input_ = torch.randn(2, 3, 4, dtype=torch.bfloat16)
+
+    actual = _sglang_cast_dense_tensor_math_input(input_)
+
+    assert actual is input_
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_batch_invariant_linear_flattens_sequence_batch_for_gemm():
+    input_ = torch.randn(4, 1, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(96, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+
+    with set_batch_invariant_mode(True):
+        actual = linear_with_grad_accumulation_and_async_allreduce(
+            input_,
+            weight,
+            bias=None,
+            gradient_accumulation_fusion=False,
+            allreduce_dgrad=False,
+            sequence_parallel=False,
+        )
+        expected = matmul_persistent(input_.detach().reshape(-1, 128), weight.detach().t())
+        expected = expected.reshape(4, 1, 96)
+
+    assert actual.dtype == torch.bfloat16
+    assert torch.equal(actual, expected)
+
+    actual.float().sum().backward()
+    assert input_.grad is not None
+    assert weight.grad is not None
+
+
+def test_sglang_output_layer_casts_input_to_weight_dtype():
+    with _fake_tp_init():
+        config = _make_config(
+            true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1, use_cpu_initialization=True
+        )
+        layer = LinearCrossEntropyModule(
+            input_size=4,
+            output_size=5,
+            config=config,
+            init_method=config.init_method,
+            bias=False,
+            gather_output=False,
+            skip_bias_add=False,
+        )
+        layer.weight.data = torch.randn_like(layer.weight.data).to(torch.bfloat16)
+        x = torch.randn(2, 3, 4, dtype=torch.float32)
+
+        actual, _ = layer(x)
+        expected = torch.matmul(x.to(torch.bfloat16), layer.weight.t())
+
+        assert actual.dtype == torch.bfloat16
+        torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_norm_layernorm_matches_torch():
+    config = _make_config(normalization="LayerNorm")
+    norm = SGLangNorm(config=config, hidden_size=4, eps=1e-5)
+    x = torch.randn(2, 3, 4)
+
+    actual = norm(x)
+    expected = torch.nn.functional.layer_norm(x, (4,), norm.weight, norm.bias, norm.eps)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_norm_rmsnorm_matches_reference():
+    config = _make_config(normalization="RMSNorm")
+    norm = SGLangNorm(config=config, hidden_size=4, eps=1e-5)
+    x = torch.randn(2, 3, 4)
+
+    actual = norm(x)
+    x_float = x.float()
+    expected = (x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + norm.eps)).type_as(
+        x
+    ) * norm.weight
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_norm_rmsnorm_keeps_affine_in_float():
+    config = _make_config(normalization="RMSNorm")
+    norm = SGLangNorm(config=config, hidden_size=4, eps=1e-5).to(dtype=torch.bfloat16)
+    x = torch.randn(2, 3, 4, dtype=torch.bfloat16)
+
+    actual = norm(x)
+    x_float = x.float()
+    expected = (x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + norm.eps)).type_as(
+        x
+    ) * norm.weight.float()
+
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_norm_rmsnorm_can_override_original_dtype():
+    config = _make_config(normalization="RMSNorm")
+    norm = SGLangNorm(config=config, hidden_size=4, eps=1e-5, override_orig_dtype=torch.float32).to(
+        dtype=torch.bfloat16
+    )
+    x = torch.randn(2, 3, 4, dtype=torch.bfloat16)
+
+    actual = norm(x)
+    x_float = x.float()
+    expected = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + norm.eps)
+    expected = norm.weight.float() * expected
+
+    assert actual.dtype == torch.float32
+    assert norm.weight.dtype == torch.float32
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_norm_rmsnorm_accepts_residual_pair():
+    config = _make_config(normalization="RMSNorm")
+    norm = SGLangNorm(config=config, hidden_size=4, eps=1e-5, override_orig_dtype=torch.float32).to(
+        dtype=torch.bfloat16
+    )
+    x = torch.randn(2, 3, 4, dtype=torch.bfloat16)
+    residual = torch.randn(2, 3, 4, dtype=torch.bfloat16)
+
+    actual, actual_residual = norm(x, residual)
+    x_float = x.float() + residual.float()
+    expected = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + norm.eps)
+    expected = norm.weight.float() * expected
+
+    assert actual.dtype == torch.float32
+    assert actual_residual.dtype == torch.float32
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(actual_residual, x_float)
+
+
+def test_sglang_qk_rmsnorm_matches_source_truth_dtype_boundary():
+    config = _make_config(normalization="RMSNorm")
+    norm = SGLangQKRMSNorm(config=config, hidden_size=4, eps=1e-6)
+    x = torch.randn(2, 3, 4, dtype=torch.bfloat16)
+
+    actual = norm(x)
+    x_float = x.float()
+    expected = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + norm.eps)
+    expected = norm.weight.float() * expected.to(torch.bfloat16)
+
+    assert norm.weight.dtype == torch.float32
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_final_rmsnorm_matches_source_truth_dtype_boundary():
+    config = _make_config(normalization="RMSNorm")
+    norm = SGLangFinalRMSNorm(config=config, hidden_size=4, eps=1e-6)
+    x = torch.randn(2, 3, 4, dtype=torch.bfloat16)
+    residual = torch.randn(2, 3, 4, dtype=torch.bfloat16)
+
+    actual, actual_residual = norm(x, residual)
+    x_with_residual = x + residual
+    x_float = x_with_residual.float()
+    expected = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + norm.eps)
+    expected = norm.weight.float() * expected.to(torch.bfloat16)
+
+    assert norm.weight.dtype == torch.float32
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(actual_residual, x_with_residual)
+
+
+def test_sglang_bias_dropout_add_keeps_residual_add_in_float():
+    x = torch.randn(2, 3, 4, dtype=torch.bfloat16)
+    residual = torch.randn(2, 3, 4, dtype=torch.float32)
+
+    actual = get_sglang_bias_dropout_add(training=False, fused=True)((x, None), residual, 0.0)
+    expected = residual + x.float()
+
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sglang_rmsnorm_rejects_zero_centered_gamma():
+    config = _make_config(normalization="RMSNorm")
+
+    with pytest.raises(AssertionError, match="zero_centered_gamma is not supported"):
+        SGLangNorm(config=config, hidden_size=4, zero_centered_gamma=True)
+
+
+def test_sglang_spec_provider_grouped_mlp_fallback():
+    provider = SGLangSpecProvider()
+
+    module, submodules = provider.grouped_mlp_modules(
+        moe_use_grouped_gemm=False, moe_use_legacy_grouped_gemm=False
+    )
+    assert module.__name__ == "SequentialMLP"
+    assert submodules.linear_fc1 is SGLangColumnParallelLinear
+    assert submodules.linear_fc2 is SGLangRowParallelLinear
+
+    grouped_module, grouped_submodules = provider.grouped_mlp_modules(
+        moe_use_grouped_gemm=True, moe_use_legacy_grouped_gemm=False
+    )
+    assert grouped_module.__name__ == "GroupedMLP"
+    assert grouped_submodules is None
+
+
+def test_sglang_mtp_spec_uses_sglang_backend():
+    config = _make_config(true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1, mtp_num_layers=1)
+    transformer_layer_spec = get_gpt_decoder_layer_specs(
+        config, use_transformer_engine=False, normalization=config.normalization
+    )[0]
+    mtp_layer_spec = get_mtp_layer_spec_for_backend(
+        transformer_layer_spec=transformer_layer_spec, backend=SGLangSpecProvider()
+    )
+
+    assert mtp_layer_spec.submodules.enorm.module is SGLangNorm
+    assert mtp_layer_spec.submodules.hnorm.module is SGLangNorm
+    assert mtp_layer_spec.submodules.eh_proj is SGLangColumnParallelLinear
+    assert mtp_layer_spec.submodules.layer_norm.module is SGLangNorm
+
+
+def test_sglang_column_parallel_linear_wrapper_forward_matches_reference():
+    with _fake_tp_init():
+        config = _make_config(
+            true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1, use_cpu_initialization=True
+        )
+        layer = SGLangColumnParallelLinear(
+            input_size=4,
+            output_size=5,
+            init_method=config.init_method,
+            bias=True,
+            config=config,
+            gather_output=False,
+            skip_bias_add=False,
+        )
+        with torch.no_grad():
+            layer.weight.copy_(torch.arange(20, dtype=torch.float32).view(5, 4))
+            layer.bias.copy_(torch.arange(5, dtype=torch.float32))
+
+        x = torch.randn(2, 3, 4)
+        actual, output_bias = layer(x)
+        expected = torch.nn.functional.linear(x, layer.weight, layer.bias)
+
+        torch.testing.assert_close(actual, expected)
+        assert output_bias is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_sglang_row_parallel_linear_wrapper_forward_matches_reference():
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1)
+    try:
+        config = _make_config(use_cpu_initialization=False)
+        layer = SGLangRowParallelLinear(
+            input_size=4,
+            output_size=5,
+            init_method=config.init_method,
+            bias=True,
+            input_is_parallel=True,
+            config=config,
+            skip_bias_add=False,
+        )
+        with torch.no_grad():
+            layer.weight.copy_(
+                torch.arange(20, dtype=torch.float32, device=layer.weight.device).view(5, 4)
+            )
+            layer.bias.copy_(torch.arange(5, dtype=torch.float32, device=layer.bias.device))
+
+        x = torch.randn(2, 3, 4, device=layer.weight.device)
+        actual, output_bias = layer(x)
+        expected = torch.nn.functional.linear(x, layer.weight, layer.bias)
+
+        torch.testing.assert_close(actual, expected)
+        assert output_bias is None
+    finally:
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/tensor_parallel/test_tree_all_reduce.py
+++ b/tests/unit_tests/tensor_parallel/test_tree_all_reduce.py
@@ -1,0 +1,136 @@
+import pytest
+import torch
+
+from megatron.core.tensor_parallel import mappings
+from megatron.core.tensor_parallel.layers import RowParallelLinear
+from megatron.core.transformer import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+class _FakeGroup:
+    def __init__(self, world_size):
+        self._world_size = world_size
+
+    def size(self):
+        return self._world_size
+
+    def rank(self):
+        return 0
+
+
+def _make_tree_gather(monkeypatch, partials):
+    def _fake_all_gather(output, input_, group=None):
+        gathered = torch.cat(partials, dim=0)
+        output.copy_(gathered)
+
+    monkeypatch.setattr(mappings, "dist_all_gather_func", _fake_all_gather)
+
+
+def _manual_tree_sum(partials):
+    running = list(partials)
+    while len(running) > 1:
+        running = [running[i] + running[i + 1] for i in range(0, len(running), 2)]
+    return running[0]
+
+
+@pytest.mark.parametrize("world_size", [2, 8])
+def test_tree_all_reduce_sum_matches_fixed_pairwise_order(monkeypatch, world_size):
+    partials = [
+        torch.full((2, 3), float(index + 1), dtype=torch.float32) for index in range(world_size)
+    ]
+    _make_tree_gather(monkeypatch, partials)
+
+    actual = mappings._tree_all_reduce_sum(partials[0].clone(), _FakeGroup(world_size))
+    expected = _manual_tree_sum(partials)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_tree_all_reduce_sum_rejects_non_power_of_two(monkeypatch):
+    partials = [torch.ones((2, 3), dtype=torch.float32) for _ in range(3)]
+    _make_tree_gather(monkeypatch, partials)
+
+    with pytest.raises(RuntimeError, match="power-of-two"):
+        mappings._tree_all_reduce_sum(partials[0].clone(), _FakeGroup(3))
+
+
+def test_row_parallel_default_path_keeps_standard_reduce(monkeypatch):
+    Utils.fake_initialize_model_parallel(tensor_model_parallel_size=1)
+    try:
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=1,
+            use_cpu_initialization=True,
+            perform_initialization=False,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+        )
+        layer = RowParallelLinear(
+            input_size=8,
+            output_size=8,
+            config=config,
+            init_method=lambda _: None,
+            bias=False,
+            input_is_parallel=True,
+            skip_bias_add=False,
+        )
+
+        calls = []
+
+        def _fake_reduce(input_, group=None, deterministic=False):
+            calls.append(deterministic)
+            return input_
+
+        monkeypatch.setattr(
+            "megatron.core.tensor_parallel.layers.reduce_from_tensor_model_parallel_region",
+            _fake_reduce,
+        )
+
+        output, _ = layer(torch.randn(2, 1, 8))
+        assert output.shape == (2, 1, 8)
+        assert calls == [False]
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def test_row_parallel_sglang_path_uses_deterministic_reduce(monkeypatch):
+    Utils.fake_initialize_model_parallel(tensor_model_parallel_size=1)
+    try:
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=1,
+            use_cpu_initialization=True,
+            perform_initialization=False,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            transformer_impl="local",
+            true_on_policy_contract="qwen3_dense_true_on_policy_v1",
+        )
+        layer = RowParallelLinear(
+            input_size=8,
+            output_size=8,
+            config=config,
+            init_method=lambda _: None,
+            bias=False,
+            input_is_parallel=True,
+            skip_bias_add=False,
+        )
+
+        calls = []
+
+        def _fake_reduce(input_, group=None, deterministic=False):
+            calls.append(deterministic)
+            return input_
+
+        monkeypatch.setattr(
+            "megatron.core.tensor_parallel.layers.reduce_from_tensor_model_parallel_region",
+            _fake_reduce,
+        )
+
+        output, _ = layer(torch.randn(2, 1, 8))
+        assert output.shape == (2, 1, 8)
+        assert calls == [True]
+    finally:
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/tensor_parallel/test_true_on_policy_logits.py
+++ b/tests/unit_tests/tensor_parallel/test_true_on_policy_logits.py
@@ -1,0 +1,38 @@
+import pytest
+import torch
+
+from megatron.core.models.gpt.gpt_model import apply_true_on_policy_logits_contract
+
+
+def test_true_on_policy_logits_contract_truncates_and_preserves_dtype():
+    full_vocab_logits = torch.tensor(
+        [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 100.0, 100.0]], dtype=torch.bfloat16
+    )
+
+    actual = apply_true_on_policy_logits_contract(full_vocab_logits, vocab_size=6)
+    expected = full_vocab_logits[:, :6]
+
+    assert actual.dtype == torch.bfloat16
+    torch.testing.assert_close(actual, expected)
+
+
+def test_true_on_policy_logprob_uses_real_vocab_after_full_gather():
+    shard_0 = torch.tensor([[1.0, 2.0, 3.0, 4.0]], dtype=torch.bfloat16)
+    shard_1 = torch.tensor([[5.0, 6.0, 100.0, 100.0]], dtype=torch.bfloat16)
+    gathered_logits = torch.cat([shard_0, shard_1], dim=-1)
+
+    contracted_logits = apply_true_on_policy_logits_contract(gathered_logits, vocab_size=6)
+    contracted_logprob = torch.nn.functional.log_softmax(contracted_logits, dim=-1)[0, 5]
+
+    wrong_full_vocab_logprob = torch.nn.functional.log_softmax(gathered_logits.float(), dim=-1)[
+        0, 5
+    ]
+    expected_logprob = torch.nn.functional.log_softmax(gathered_logits[:, :6], dim=-1)[0, 5]
+
+    torch.testing.assert_close(contracted_logprob, expected_logprob)
+    assert not torch.allclose(contracted_logprob.float(), wrong_full_vocab_logprob)
+
+
+def test_true_on_policy_logits_contract_rejects_vocab_larger_than_logits():
+    with pytest.raises(RuntimeError, match="exceeds gathered logits width"):
+        apply_true_on_policy_logits_contract(torch.randn(2, 4), vocab_size=5)


### PR DESCRIPTION
# PR: Add TV (total-variation) loss option for the MTP draft head

**Repo:** `radixark/Megatron-LM`  **Base:** `miles-main` @ `36ceb4fc0`  **Branch:** `feat/mtp-tv-loss`
**Files:** `megatron/core/models/gpt/gpt_model.py` (+106), `megatron/core/transformer/transformer_config.py` (+13)

## Motivation
The MTP draft head is trained with cross-entropy. But for speculative decoding the
rejection-sampling acceptance rate is `accept_rate = 1 - d_TV(p_main, q_draft)`, so
**total variation is the direct objective**; CE only bounds TV via Pinsker. Optimizing TV
directly heals the draft head faster (esp. when the main model has drifted from the head's
training distribution — e.g. an official MTP head grafted onto an SFT'd / RL'd main model).

Ref: *"Breaking Entropy Bounds: Accelerating RL Training via MTP with Rejection Sampling"* (Bebop).

## What it adds
- `TransformerConfig.mtp_loss_type` (`'ce'` default | `'tv'`) and `mtp_tv_chunk: int = 0`.
  Auto-exposed as `--mtp-loss-type` / `--mtp-tv-chunk` (ArgumentGroupFactory) and mapped back
  via `core_transformer_config_from_args` — no manual arg wiring.
- `GPTModel`: when `mtp_loss_type == 'tv'`, the MTP-loss branch computes per token
  `1 - Σ_v min(softmax(p_main).detach(), softmax(q_draft))`. `p_main` is the main model's
  next-token distribution (fully detached; main hidden states are rolled to align with the
  MTP target, mirroring the existing label shift). Produces `mtp_loss` in the same `[b, s]`
  layout as the CE branch, so the existing `MTPLossAutoScaler` / scaling / logging path is
  unchanged — it's a drop-in alternative to the CE branch.
- `mtp_tv_chunk > 0` chunks the vocab-sum over the sequence dim and **gradient-checkpoints
  each chunk** (recomputes softmax in backward), so backward memory is ~one chunk instead of
  O(T·V) — this is what lets TV fit alongside full-backbone (joint) training.

## Limitation
TV needs the full vocabulary per rank for `Σ_v min(p,q)`, so it requires
**tensor-model-parallel size 1** (raises `NotImplementedError` for TP>1). Vocab-parallel TV
(all-reduce of the min-overlap) is possible future work.

## Validation
Trained the Qwen3.5-35B-A3B grafted MTP head with `--mtp-loss-type tv --mtp-tv-chunk 512`
(freeze + joint), 300 steps each, on the miles RL stack; `mtp_loss` (= mean TV) ~0.13–0.15,
no OOM with chunking, spec accept-rate tracked as expected. CE path unchanged (default).

## Notes for reviewers
- Default behavior is identical (`mtp_loss_type='ce'`).
- `--mtp-tv-chunk` only affects the TV path; ignored for CE.
- Companion (separate) change in miles: none required — it forwards Megatron args; an optional
  `reset_arg` could surface `--mtp-loss-type` explicitly.
