### PR TITLE
[AMD] Fix QuantizedTensor import for ROCm TransformerEngine 2.8

### DIFF
--- a/megatron/core/optimizer/fused_adam_patch.py
+++ b/megatron/core/optimizer/fused_adam_patch.py
@@ -20,8 +20,8 @@ def _patched_initialize_state(self, param, state_name, zero_buffer, store_param_
     """Patched _initialize_state: allocate on CPU for low-memory resume."""
     from transformer_engine.pytorch.tensor.float8_tensor import Float8Quantizer
     try:
-        from transformer_engine.pytorch.tensor import QuantizedTensor  # TE >= 2.x
-    except ImportError:  # older TE layout
+        from transformer_engine.pytorch.tensor import QuantizedTensor
+    except ImportError:
         from transformer_engine.pytorch.quantized_tensor import QuantizedTensor
     import transformer_engine_torch as tex
 

--- a/megatron/core/optimizer/fused_adam_patch.py
+++ b/megatron/core/optimizer/fused_adam_patch.py
@@ -19,7 +19,10 @@ _patch_applied = False
 def _patched_initialize_state(self, param, state_name, zero_buffer, store_param_remainders=False):
     """Patched _initialize_state: allocate on CPU for low-memory resume."""
     from transformer_engine.pytorch.tensor.float8_tensor import Float8Quantizer
-    from transformer_engine.pytorch.quantized_tensor import QuantizedTensor
+    try:
+        from transformer_engine.pytorch.tensor import QuantizedTensor  # TE >= 2.x
+    except ImportError:  # older TE layout
+        from transformer_engine.pytorch.quantized_tensor import QuantizedTensor
     import transformer_engine_torch as tex
 
     dtype = self.name_to_dtype_map[state_name]


### PR DESCRIPTION
## Summary

ROCm TransformerEngine 2.8 moved `QuantizedTensor` from `transformer_engine.pytorch.quantized_tensor` to `transformer_engine.pytorch.tensor`.

This caused checkpoint loading with `--low-memory-resume` to fail with `ModuleNotFoundError`.

This change uses the new import path first and falls back to the old path for compatibility with other TransformerEngine versions. NVIDIA behavior is unchanged.

## Testing

Verified on 8 MI355X GPUs with:

`tests/e2e/ckpt/test_qwen3_4B_ckpt.py`

The complete save / load / async_save / load sequence passes. Both load stages report matching model hashes at iteration 2.

Before this change, the first load stage failed while importing `QuantizedTensor`.