### PR TITLE
Restore enforce_marked_param_dtypes after model materialization

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1274,6 +1274,12 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
     # After TE2.x: Below function is an empty function and does nothing.
     correct_amax_history_if_needed(model)
 
+    # Miles allows selected parameters to opt out of Float16Module's global
+    # bf16/fp16 cast. Restore those dtypes immediately after model materialization.
+    from miles.backends.megatron_utils.fp32_param_utils import enforce_marked_param_dtypes
+
+    enforce_marked_param_dtypes(model)
+
     if wrap_with_ddp:
         if args.use_torch_fsdp2:
             assert HAVE_FSDP2, "Torch FSDP2 requires torch>=2.4.0"


### PR DESCRIPTION
## What

Restores the call to `enforce_marked_param_dtypes(model)` in `get_model` ([megatron/training/training.py](megatron/training/training.py)), right after `correct_amax_history_if_needed(model)` and before the DDP wrap.

```python
# Miles allows selected parameters to opt out of Float16Module's global
# bf16/fp16 cast. Restore those dtypes immediately after model materialization.
from miles.backends.megatron_utils.fp32_param_utils import enforce_marked_param_dtypes

enforce_marked_param_dtypes(model)
```

## Why

[PR #28](https://github.com/radixark/Megatron-LM/pull/28) (DeepSeek V4 RL support) removed this block. Miles allows selected parameters to opt out of `Float16Module`'s global bf16/fp16 cast; this call restores those dtypes immediately after model materialization. Without it, marked fp32 params get silently cast, so the block is added back.

This change is an exact revert of the removal in PR #28 — the resulting file is byte-identical to the pre-#28 state.

## Acknowledgements

Thanks to @zyzshishui for finding this bug. 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)