### PR TITLE
Route dsa/dsv4 through the experimental attention variant module spec dispatch

### DIFF
--- a/megatron/core/models/gpt/experimental_attention_variant_module_specs.py
+++ b/megatron/core/models/gpt/experimental_attention_variant_module_specs.py
@@ -123,6 +123,7 @@ def get_dsa_module_spec_for_backend(
             q_layernorm=IdentityOp,
             kv_layernorm=IdentityOp,
         ),
+        metainfo={"fuse_input_layernorm": False},
     )
 
     return attention

--- a/megatron/core/models/gpt/experimental_attention_variant_module_specs.py
+++ b/megatron/core/models/gpt/experimental_attention_variant_module_specs.py
@@ -138,6 +138,8 @@ def get_experimental_attention_variant_module_spec(
 
     if config.experimental_attention_variant == "gated_delta_net":
         return get_gated_delta_net_module_spec(config=config, backend=backend)
+    elif config.experimental_attention_variant in ("dsa", "dsv4"):
+        return get_dsa_module_spec_for_backend(config=config, backend=backend)
     else:
         raise ValueError(
             f"Invalid experimental attention variant: {config.experimental_attention_variant}"


### PR DESCRIPTION
## Problem

Building a DSA model (GLM-5.x, `experimental_attention_variant="dsa"`) through megatron-core's experimental-attention spec path crashes at model construction, in two layers:

1. `get_experimental_attention_variant_module_spec` (megatron/core/models/gpt/experimental_attention_variant_module_specs.py) only handles `gated_delta_net` and raises for everything else:

   ```
   ValueError: Invalid experimental attention variant: dsa
   ```

   `get_dsa_module_spec_for_backend` already exists in the same file (with the DSA imports at the top), but it was never wired into this dispatch — it was dead code.

2. Once dispatched, the heterogeneous layer builder reads `attention.metainfo["fuse_input_layernorm"]`, which the DSA spec never set:

   ```
   KeyError: 'fuse_input_layernorm'
   ```

## Fix

Two commits, both aligning with NVIDIA upstream `main`, which already carries exactly these semantics:

1. Route `"dsa"` / `"dsv4"` to the existing `get_dsa_module_spec_for_backend` (upstream dispatches the same way; the variant values mirror `multi_latent_attention.py`'s `in ("dsa", "dsv4")`).
2. Set `metainfo={"fuse_input_layernorm": False}` on the DSA attention spec — DSA is MLA-based, and both the standard-attention MLA path here and upstream's DSA spec use `False`.

## Relationship to Megatron-Bridge's GLM5 shim (why this PR is cleanup, not a hard requirement)

radixark/Megatron-Bridge's `_build_glm5_dsa_block_spec` (models/glm5/glm5_bridge.py, merged 2026-07-07) works around exactly these two gaps at runtime: it prefers megatron-core's native handling, and only when the dispatcher raises `ValueError` for `"dsa"` (old megatron-core) back-fills via the shipped DSA builder and sets `metainfo["fuse_input_layernorm"]=False`. Its docstring notes: *"once the runtime's megatron-core handles `dsa`, this whole helper can be deleted."*

This PR is that megatron-core-side fix: with it, the bridge shim's back-fill branch becomes dead code and can eventually be removed. Without it, GLM5 DSA keeps working through the shim — so this is correctness/cleanup alignment with upstream, not a blocker.

## How this was found

Triaging the `stage-c-8-gpu-h100` failures on radixark/miles#1596 (`tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_lora_ci.py`, `test_glm5_1_744b_a40b_6layer_lora_ci.py`, introduced by radixark/miles#1559): with the then-current `radixark/miles:dev` image (whose Megatron-Bridge predates GLM5Bridge, so no shim), attempt 1 hit the ValueError; attempt 2 (with commit 1 of this PR pinned via `ci-megatron-pr:`) got past it and hit the KeyError, confirming the layering. The remaining image-side gap is resolved by rebuilding the image so it picks up Megatron-Bridge's GLM5 support.
