### PR TITLE
dist_checkpointing: fix dp_reshardable optimizer resume for uneven-param (MoE) models

### DIFF
--- a/megatron/core/dist_checkpointing/dict_utils.py
+++ b/megatron/core/dist_checkpointing/dict_utils.py
@@ -233,8 +233,16 @@ def _is_optimizer_param_state_key(key: Tuple) -> bool:
 def merge(x1: Union[dict, list], x2: Union[dict, list], key: Tuple[Union[str, int], ...] = ()):
     """Merges dicts and lists recursively.
 
-    For optimizer param_state paths, allows x1 to be longer than x2
-    (dp_reshardable padding entries are truncated).
+    For optimizer ``param_state`` lists, the two sides can legitimately differ in length: the
+    distributed optimizer's per-parameter ``param_state`` list is written into the (rank-0-only)
+    *common* state, but its length is a per-rank quantity — the equal-byte DP slice of a bucket
+    contains a different number of parameters on each rank when parameter sizes are uneven (e.g. a
+    large MoE grouped-expert weight vs. tiny norms). So the saved list (x1) reflects only one rank
+    and can be longer *or* shorter than this rank's loaded list (x2). x2 carries this rank's correct
+    per-parameter moments (resharded by byte offset), so it is authoritative:
+      - x1 longer  -> trailing entries are dp_reshardable padding; drop them.
+      - x1 shorter -> adopt x2's structure; ``step`` is uniform across params, so carry it forward.
+    (Real size changes are still guarded by the ``per_bucket_numel_unpadded`` assert on load.)
     """
     if isinstance(x1, dict) and isinstance(x2, dict):
         for k, v2 in x2.items():
@@ -246,6 +254,16 @@ def merge(x1: Union[dict, list], x2: Union[dict, list], key: Tuple[Union[str, in
         if len(x1) != len(x2):
             if _is_optimizer_param_state_key(key) and len(x1) > len(x2):
                 del x1[len(x2):]
+            elif _is_optimizer_param_state_key(key):
+                saved_step = next(
+                    (e["step"] for e in x1 if isinstance(e, dict) and "step" in e), None
+                )
+                x1[:] = x2
+                if saved_step is not None:
+                    for e in x1:
+                        if isinstance(e, dict) and "step" in e:
+                            e["step"] = saved_step
+                return x1
             else:
                 raise ValueError(
                     f"Cannot merge two lists with different lengths ({len(x1)} and {len(x2)}, "


### PR DESCRIPTION
## Summary

Fixes a crash when **resuming the distributed optimizer from a `dp_reshardable` checkpoint for models with very uneven parameter sizes** (e.g. MoE grouped-expert weights + a large vocab embedding alongside tiny norms). Resume fails during load with:

```
ValueError: Cannot merge two lists with different lengths (1 and N,
  encountered at level ('optimizer', 0, 'param_state', 0, (torch.bfloat16, torch.float32), 0))
```

## Root cause

The distributed optimizer's per-parameter `param_state` list is serialized into the **rank‑0‑only "common"** state, but its **length is a per‑rank quantity**. The distributed optimizer shards each grad buffer bucket into equal‑byte contiguous DP slices; when parameter sizes are uneven, the number of parameters landing in a given rank's slice **differs across ranks** (one rank's slice can sit entirely inside a single large weight → length 1; another rank's slice spans many small params → length N).

So the saved "common" list reflects only rank 0's count. On resume every rank whose per‑rank count differs from rank 0's fails in `merge()` when it tries to align the saved list (length 1) with its own loaded list (length N).

The moment tensors themselves reshard correctly by byte offset **independently** of this list, and `step` is uniform across params, so the loaded per‑rank list is authoritative.

## Fix

In `dict_utils.merge`, on the optimizer‑`param_state` path, when the saved list length differs from this rank's loaded list, **adopt the loaded list** (carrying the uniform `step` forward). This mirrors the handling that already exists for the opposite direction (`x1 > x2`, dp_reshardable padding).

- **No save‑side change** → both existing and future `dp_reshardable` checkpoints resume with full optimizer state.
- **Backward compatible** → symmetric checkpoints (matching lengths) are unaffected.
- Real size changes remain guarded by the existing `per_bucket_numel_unpadded` assert in `load_parameter_state_from_dp_reshardable`.

## Why it only surfaces on some models

With uniform parameter sizes (dense stacks, small/uniform MoE) the equal‑byte DP slices cut the same number of params on every rank, so the `param_state` list really is rank‑invariant and the round‑trip works — which is why this hasn't been seen on typical configs. It requires extreme param‑size disparity to diverge. (The save‑time common‑consistency check only warns, so the inconsistent checkpoint is written silently.)

## Validation

Reproduced and validated **at real scale** on the actual model that hit it — a 35B MoE (Qwen3.6‑35B‑A3B), `TP2·CP4·EP8`, precision‑aware + CPU‑offloaded distributed optimizer, 32 GPUs, loading a real `dp_reshardable` checkpoint:

- **Before:** `Cannot merge two lists (1 and 41/46/50/58/61/62)` — per‑rank `param_state` counts genuinely differed (a length‑1 rank's slice was entirely inside one `(124160, 2048)` vocab weight; others spanned 41–62 small params).
- **After (this fix, with the weights‑only fallback disabled):** all 32 ranks load `iteration=24` with **non‑zero Adam moments** (`sum|exp_avg|` 5e1–1.7e2, 653–712 params/rank), **no merge crash** — full optimizer state restored per rank.

## Caveat

Validated via the real 32‑GPU load rather than a unit test: the bug only manifests with real param‑size disparity at scale, so a synthetic small‑scale reproduction wasn't representative. A deterministic regression test using deliberately uneven parameter sizes would be a good follow‑up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
