### PR TITLE
Fix CPU-offloaded optimizer state dtypes

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -319,6 +319,10 @@ def _get_megatron_optimizer_based_on_param_groups(
             if config.optimizer == 'adam':
                 gpu_optimizer_cls = Adam
                 cpu_optimizer_cls = CPUAdam
+                if config.main_params_dtype != torch.float32:
+                    # HybridDeviceOptimizer owns the main-parameter copy. Native AdamW
+                    # keeps the GPU slice's states in that same configured dtype.
+                    gpu_optimizer_cls = CPUAdam
                 optimizer_defaults = dict(
                     lr=config.lr,
                     weight_decay=config.weight_decay,
@@ -341,7 +345,9 @@ def _get_megatron_optimizer_based_on_param_groups(
                 overlap_cpu_optimizer_d2h_h2d=config.overlap_cpu_optimizer_d2h_h2d,
                 pin_cpu_grads=config.pin_cpu_grads,
                 pin_cpu_params=config.pin_cpu_params,
-                param_update_in_fp32=True,
+                main_params_dtype=config.main_params_dtype,
+                exp_avg_dtype=config.exp_avg_dtype,
+                exp_avg_sq_dtype=config.exp_avg_sq_dtype,
                 **optimizer_defaults,
             )
             init_state_fn = None

--- a/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
+++ b/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2025, NVIDIA CORPORATION and Alibaba PAI. All rights reserved.
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, Optional
 
 import torch
 
@@ -49,11 +49,24 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         cpu_optimizer_cls=None,
         gpu_optimizer_cls=None,
         param_update_in_fp32: bool = False,
+        main_params_dtype: Optional[torch.dtype] = None,
+        exp_avg_dtype: Optional[torch.dtype] = None,
+        exp_avg_sq_dtype: Optional[torch.dtype] = None,
         pin_cpu_grads: bool = True,
         pin_cpu_params: bool = True,
         overlap_cpu_optimizer_d2h_h2d: bool = True,
         **kwargs,
     ):
+        configured_dtypes = (main_params_dtype, exp_avg_dtype, exp_avg_sq_dtype)
+        if any(dtype is not None for dtype in configured_dtypes):
+            assert (
+                all(dtype is not None for dtype in configured_dtypes)
+                and len(set(configured_dtypes)) == 1
+            ), "main_params_dtype, exp_avg_dtype, and exp_avg_sq_dtype must use the same dtype"
+            assert not param_update_in_fp32 or main_params_dtype == torch.float32, (
+                "param_update_in_fp32=True conflicts with a non-FP32 " "main_params_dtype"
+            )
+
         super(HybridDeviceOptimizer, self).__init__(
             params,
             defaults={
@@ -61,6 +74,9 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                 "cpu_optimizer_cls": cpu_optimizer_cls,
                 "gpu_optimizer_cls": gpu_optimizer_cls,
                 "param_update_in_fp32": param_update_in_fp32,
+                "main_params_dtype": main_params_dtype,
+                "exp_avg_dtype": exp_avg_dtype,
+                "exp_avg_sq_dtype": exp_avg_sq_dtype,
                 "pin_cpu_grads": pin_cpu_grads,
                 "pin_cpu_params": pin_cpu_params,
                 "overlap_cpu_optimizer_d2h_h2d": overlap_cpu_optimizer_d2h_h2d,
@@ -75,25 +91,25 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         self.pin_cpu_params = pin_cpu_params
         self.overlap_cpu_optimizer_d2h_h2d = overlap_cpu_optimizer_d2h_h2d
         self.param_update_in_fp32 = param_update_in_fp32
+        self.main_params_dtype = (
+            torch.float32
+            if param_update_in_fp32 and main_params_dtype is None
+            else main_params_dtype
+        )
+        self.exp_avg_dtype = exp_avg_dtype
+        self.exp_avg_sq_dtype = exp_avg_sq_dtype
+        self.use_main_param_copy = self.main_params_dtype is not None
         self.sub_optimizer_kwargs = kwargs
 
         self._init_sub_optimizers()
         self._register_load_state_dict_hooks()
 
     def _set_sub_optimizer_grads(self):
-        if self.param_update_in_fp32:
-            for param in self.param_to_fp32_param:
-                if param in self.gpu_params_map_cpu_copy:
-                    # Skip if the param is offloaded to CPU, it should be handled
-                    # in the following part.
-                    continue
-                fp32_param = self.param_to_fp32_param[param]
-                grad = getattr(param, "decoupled_grad", param.grad)
-                if grad is not None:
-                    fp32_param.grad = grad.to(fp32_param.dtype)
-                    fp32_param.requires_grad = True
-                else:
-                    fp32_param.requires_grad = False
+        if self.gpu_optimizer is not None:
+            for inner_param in _param_generator(self.gpu_optimizer):
+                orig_param = self.inner_param_to_orig_param[inner_param]
+                grad = getattr(orig_param, "decoupled_grad", orig_param.grad)
+                inner_param.grad = None if grad is None else grad.to(inner_param.dtype)
 
         # Sync the grads from GPU to CPU.
         for optimizer in self.cpu_optimizers:
@@ -126,8 +142,8 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
 
             return param_copy_back_gpu_hook
 
-        def fp32_param_copy_back_gpu_hook_closure():
-            def fp32_param_copy_back_gpu_hook(optimizer, args, kwargs):
+        def main_param_copy_back_gpu_hook_closure():
+            def main_param_copy_back_gpu_hook(optimizer, args, kwargs):
                 for group in self.param_groups:
                     for param in group["params"]:
                         if param in self.gpu_params_map_cpu_copy:
@@ -135,17 +151,17 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                             # copied back in the previous hook.
                             continue
 
-                        if param in self.param_to_fp32_param:
-                            fp32_param = self.param_to_fp32_param[param]
-                            param.data.copy_(fp32_param.data)
+                        if param in self.param_to_main_param:
+                            main_param = self.param_to_main_param[param]
+                            param.data.copy_(main_param.data)
 
-            return fp32_param_copy_back_gpu_hook
+            return main_param_copy_back_gpu_hook
 
         for optimizer in self.sub_optimizers:
             if optimizer is not self.gpu_optimizer:
                 optimizer.register_step_post_hook(param_copy_back_gpu_hook_closure())
-            elif self.param_update_in_fp32:
-                optimizer.register_step_post_hook(fp32_param_copy_back_gpu_hook_closure())
+            elif self.use_main_param_copy:
+                optimizer.register_step_post_hook(main_param_copy_back_gpu_hook_closure())
 
     def step(self, closure=None):
         """
@@ -184,21 +200,27 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
             self.gpu_param_groups,
             self.gpu_params_map_cpu_copy,
             self.cpu_copys_map_gpu_param,
-            self.param_to_fp32_param,
+            self.param_to_main_param,
         ) = self._get_sub_optimizer_param_groups(self.offload_fraction)
         self.param_to_inner_param = {}
         self.inner_param_to_orig_param = {}
         for group in self.param_groups:
             for param in group["params"]:
-                if param in self.param_to_fp32_param:
-                    inner_param = self.param_to_fp32_param[param]
+                if param in self.param_to_main_param:
+                    inner_param = self.param_to_main_param[param]
                 elif param in self.gpu_params_map_cpu_copy:
                     inner_param = self.gpu_params_map_cpu_copy[param]
                 else:
                     inner_param = param
                 self.param_to_inner_param[param] = inner_param
                 self.inner_param_to_orig_param[inner_param] = param
-        self.fp32_param_to_orig_param = {v: k for k, v in self.param_to_fp32_param.items()}
+        self.main_param_to_orig_param = {v: k for k, v in self.param_to_main_param.items()}
+        if self.param_update_in_fp32:
+            self.param_to_fp32_param = self.param_to_main_param
+            self.fp32_param_to_orig_param = self.main_param_to_orig_param
+        else:
+            self.param_to_fp32_param = {}
+            self.fp32_param_to_orig_param = {}
 
         self.cpu_optimizers = []
         if self.overlap_cpu_optimizer_d2h_h2d:
@@ -261,7 +283,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         gpu_param_groups = []
         gpu_params_map_cpu_copy = {}
         cpu_copys_map_gpu_param = {}
-        param_to_fp32_param = {}
+        param_to_main_param = {}
         for group in self.param_groups:
             gpu_group = group.copy()
             cpu_group = group.copy()
@@ -271,12 +293,21 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                 orig_param = param
                 cpu_copy = False
                 if offload_params_numel < offload_threshold and param.is_cuda:
-                    param = param.detach().clone().cpu().pin_memory()
+                    cpu_param = torch.empty_like(
+                        param,
+                        dtype=self.main_params_dtype or param.dtype,
+                        device="cpu",
+                        pin_memory=self.pin_cpu_params,
+                    )
+                    cpu_param.copy_(param.detach(), non_blocking=False)
+                    param = cpu_param
                     offload_params_numel += param.numel()
                     cpu_copy = True
-                if self.param_update_in_fp32 and param.dtype != torch.float32:
-                    param = param.detach().clone().float()
-                    param_to_fp32_param[orig_param] = param
+                elif self.use_main_param_copy and param.dtype != self.main_params_dtype:
+                    param = param.detach().to(dtype=self.main_params_dtype, copy=True)
+
+                if self.use_main_param_copy and param is not orig_param:
+                    param_to_main_param[orig_param] = param
 
                 if cpu_copy:
                     gpu_params_map_cpu_copy[orig_param] = param
@@ -296,7 +327,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
             gpu_param_groups,
             gpu_params_map_cpu_copy,
             cpu_copys_map_gpu_param,
-            param_to_fp32_param,
+            param_to_main_param,
         )
 
     def _sync_sub_optimizers_state_to_hdo(self):
@@ -316,7 +347,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
             for param in optimizer.state:
                 orig_param = self.inner_param_to_orig_param[param]
                 new_state[orig_param] = optimizer.state[param]
-                if self.param_update_in_fp32:
+                if self.use_main_param_copy:
                     new_state[orig_param]["master_param"] = param
         self.state = new_state
 
@@ -328,7 +359,10 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                     orig_param = self.inner_param_to_orig_param[param]
                     new_state[param] = self.state[orig_param]
             optimizer.state = new_state
-        self._update_fp32_params_by_new_state()
+        self._update_main_params_by_new_state()
+        if self.use_main_param_copy:
+            for param, state in self.state.items():
+                state["master_param"] = self.param_to_inner_param.get(param, param)
         self._move_new_state_to_right_device()
 
     def _sync_hdo_param_groups_to_sub_optimizers(self):
@@ -361,13 +395,13 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                     if not isinstance(v, torch.Tensor):
                         continue
                     orig_param = self.inner_param_to_orig_param.get(param, param)
-                    if isinstance(optimizer, self.defaults["cpu_optimizer_cls"]):
+                    if optimizer in self.cpu_optimizers:
                         self.state[orig_param][k] = state[k] = v.to("cpu")
                     else:
                         self.state[orig_param][k] = state[k] = v.to("cuda")
 
-    def _update_fp32_params_by_new_state(self):
-        if not self.param_update_in_fp32:
+    def _update_main_params_by_new_state(self):
+        if not self.use_main_param_copy:
             return
         for param, v in self.state.items():
             inner_param = self.param_to_inner_param.get(param, param)
@@ -378,7 +412,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
             # non_blocking CPU tensor can race with the following CPU copy.
             inner_param.data.copy_(v["master_param"].detach(), non_blocking=False)
 
-    def update_fp32_param_by_new_param(self):
+    def update_main_param_by_new_param(self):
         """
         Refresh optimizer-side parameter copies after model weights are loaded
         or otherwise changed outside the optimizer.
@@ -386,56 +420,59 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         for param, inner_param in self.param_to_inner_param.items():
             if inner_param is param:
                 continue
-            # Blocking direct D2H copy is required here. 
+            # Blocking direct D2H copy is required here.
             inner_param.data.copy_(param.detach(), non_blocking=False)
+
+    def update_fp32_param_by_new_param(self):
+        """Backward-compatible alias for updating optimizer-side main parameters."""
+        self.update_main_param_by_new_param()
 
     def _register_load_state_dict_hooks(self):
         def pre_load_state_dict_hook(self, state_dict):
             """
-            Pre-load state dictionary hook to prevent loss of precision in
-            mixed-precision training.
+            Replace model parameters with optimizer-side main parameters before loading.
 
             When loading a state dictionary with `torch.load_state_dict`,
             optimizer states are reset and cast from `float32` to `bfloat16`/`float16`,
-            potentially losing precision. This hook replaces parameters with
-            their `float32` copies to mitigate this issue.
+            potentially losing precision. This hook uses the configured main-parameter
+            dtype for that conversion.
 
             Args:
                 state_dict (dict): The state dictionary to be loaded.
 
             Returns:
-                dict: The modified state dictionary with `float32` parameters.
+                dict: The state dictionary prepared for optimizer-side main parameters.
             """
-            if not self.param_update_in_fp32:
+            if not self.use_main_param_copy:
                 return state_dict
 
             new_state = {}
             for param, v in self.state.items():
-                param = self.param_to_fp32_param.get(param, param)
+                param = self.param_to_main_param.get(param, param)
                 new_state[param] = v
             self.state = new_state
 
             for group in self.param_groups:
                 for i, param in enumerate(group["params"]):
-                    group["params"][i] = self.param_to_fp32_param.get(param, param)
+                    group["params"][i] = self.param_to_main_param.get(param, param)
 
             return state_dict
 
         self.register_load_state_dict_pre_hook(pre_load_state_dict_hook)
 
         def post_load_state_dict_hook(self):
-            # 1. Replace the temporarily replaced fp32 parameters back. Please
+            # 1. Replace the temporarily substituted main parameters. Please
             # refer to the documentation in `pre_load_state_dict_hook`.
-            if self.param_update_in_fp32:
+            if self.use_main_param_copy:
                 new_state = {}
                 for param, v in self.state.items():
-                    orig_param = self.fp32_param_to_orig_param.get(param, param)
+                    orig_param = self.main_param_to_orig_param.get(param, param)
                     new_state[orig_param] = v
                 self.state = new_state
 
                 for group in self.param_groups:
                     for i, param in enumerate(group["params"]):
-                        group["params"][i] = self.fp32_param_to_orig_param.get(param, param)
+                        group["params"][i] = self.main_param_to_orig_param.get(param, param)
 
             # 2. After loading state_dict, the parameters may change, and we need to
             # reinitialize the sub-optimizers to regenerate the new parameters and

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -395,6 +395,10 @@ class OptimizerConfig:
             # --use-precision-aware-optimizer.
             # TODO: Remove this check when apex's FusedAdam is no longer used.
             if self.optimizer_cpu_offload:
+                assert self.main_params_dtype == self.exp_avg_dtype == self.exp_avg_sq_dtype, (
+                    "optimizer CPU offload main_params_dtype, exp_avg_dtype, and "
+                    "exp_avg_sq_dtype must use the same dtype"
+                )
                 return
             try:
                 import inspect

--- a/tests/unit_tests/test_optimizer_cpu_offloading.py
+++ b/tests/unit_tests/test_optimizer_cpu_offloading.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
-import copy
 import random
-from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -18,7 +16,6 @@ except:
     from torch.optim import SGD as GPUSGD
     from torch.optim import Adam as GPUAdam
 
-from megatron.core.optimizer import OptimizerConfig, _get_megatron_optimizer_based_on_param_groups
 from megatron.core.optimizer.cpu_offloading import HybridDeviceOptimizer
 
 
@@ -142,132 +139,3 @@ def test_multi_device_hybrid_optimizer(
         assert torch.allclose(
             v, ref_params[k], atol=1e-03
         ), f"Weight {k} value mismatch, max error: {(v - ref_params[k]).abs().max()}"
-
-
-@pytest.mark.skipif(torch.__version__ < '2.3.0', reason="Requires PyTorch 2.3.0 or higher")
-@pytest.mark.parametrize("offload_fraction", [0.5, 1.0])
-@pytest.mark.parametrize("model_params_dtype", [torch.bfloat16, torch.float16])
-def test_precision_aware_cpu_offload_state_dtypes(offload_fraction, model_params_dtype):
-    model_params = [
-        torch.nn.Parameter(torch.ones(32, dtype=model_params_dtype, device="cuda"))
-        for _ in range(2)
-    ]
-    config = OptimizerConfig(
-        optimizer="adam",
-        lr=1e-2,
-        fp16=model_params_dtype == torch.float16,
-        bf16=model_params_dtype == torch.bfloat16,
-        params_dtype=model_params_dtype,
-        use_distributed_optimizer=True,
-        optimizer_cpu_offload=True,
-        optimizer_offload_fraction=offload_fraction,
-        overlap_cpu_optimizer_d2h_h2d=False,
-        use_precision_aware_optimizer=True,
-        main_params_dtype=torch.float16,
-        exp_avg_dtype=torch.float16,
-        exp_avg_sq_dtype=torch.float16,
-        decoupled_weight_decay=True,
-    )
-
-    with (
-        patch(
-            "megatron.core.optimizer.DistributedOptimizer",
-            side_effect=lambda optimizer, *args, **kwargs: optimizer,
-        ),
-        patch(
-            "megatron.core.optimizer.parallel_state.get_tensor_model_parallel_group",
-            return_value=None,
-        ),
-    ):
-        optimizer = _get_megatron_optimizer_based_on_param_groups(
-            config=config, model_chunks=[], param_groups=[{"params": model_params}]
-        )
-
-    assert isinstance(optimizer, HybridDeviceOptimizer)
-    assert not optimizer.state
-    assert not optimizer.param_to_fp32_param
-    assert not optimizer.fp32_param_to_orig_param
-    initial_inner_params = {
-        model_param: optimizer.param_to_inner_param[model_param].detach().clone()
-        for model_param in model_params
-    }
-
-    for model_param in model_params:
-        model_param.decoupled_grad = torch.ones_like(model_param, dtype=torch.float32)
-    optimizer.step()
-    for model_param in model_params:
-        assert not torch.equal(
-            initial_inner_params[model_param], optimizer.param_to_inner_param[model_param]
-        )
-
-    def assert_state_dtypes():
-        devices = set()
-        for model_param in model_params:
-            master_param = optimizer.param_to_inner_param[model_param]
-            state = optimizer.state[model_param]
-            devices.add(master_param.device.type)
-            assert state["master_param"] is master_param
-            assert master_param.dtype == torch.float16
-            assert master_param.element_size() == 2
-            assert state["exp_avg"].device == master_param.device
-            assert state["exp_avg"].dtype == torch.float16
-            assert state["exp_avg_sq"].device == master_param.device
-            assert state["exp_avg_sq"].dtype == torch.float16
-
-        expected_devices = {"cpu", "cuda"} if offload_fraction == 0.5 else {"cpu"}
-        assert devices == expected_devices
-
-    assert_state_dtypes()
-
-    expected_state = {
-        model_param: {
-            key: optimizer.state[model_param][key].detach().clone()
-            for key in ("master_param", "exp_avg", "exp_avg_sq")
-        }
-        for model_param in model_params
-    }
-    state_dict = copy.deepcopy(optimizer.state_dict())
-    with torch.no_grad():
-        for model_param in model_params:
-            inner_param = optimizer.param_to_inner_param[model_param]
-            if inner_param is not model_param:
-                model_param.fill_(7)
-                inner_param.zero_()
-            optimizer.state[model_param]["exp_avg"].zero_()
-            optimizer.state[model_param]["exp_avg_sq"].zero_()
-
-    optimizer.load_state_dict(state_dict)
-    assert_state_dtypes()
-    for model_param in model_params:
-        state = optimizer.state[model_param]
-        for key in ("master_param", "exp_avg", "exp_avg_sq"):
-            torch.testing.assert_close(state[key], expected_state[model_param][key], rtol=0, atol=0)
-
-    for model_param in model_params:
-        model_param.decoupled_grad = torch.ones_like(model_param, dtype=torch.float32)
-    optimizer.step()
-    assert_state_dtypes()
-
-
-def test_precision_aware_cpu_offload_rejects_mixed_state_dtypes():
-    with pytest.raises(AssertionError, match="must use the same dtype"):
-        OptimizerConfig(
-            optimizer="adam",
-            use_distributed_optimizer=True,
-            optimizer_cpu_offload=True,
-            use_precision_aware_optimizer=True,
-            main_params_dtype=torch.float32,
-            exp_avg_dtype=torch.float16,
-            exp_avg_sq_dtype=torch.bfloat16,
-        )
-
-
-def test_hybrid_optimizer_rejects_legacy_fp32_flag_with_low_precision_dtypes():
-    with pytest.raises(AssertionError, match="param_update_in_fp32=True conflicts"):
-        HybridDeviceOptimizer(
-            [],
-            param_update_in_fp32=True,
-            main_params_dtype=torch.float16,
-            exp_avg_dtype=torch.float16,
-            exp_avg_sq_dtype=torch.float16,
-        )

--- a/tests/unit_tests/test_optimizer_cpu_offloading.py
+++ b/tests/unit_tests/test_optimizer_cpu_offloading.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+import copy
 import random
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -16,6 +18,7 @@ except:
     from torch.optim import SGD as GPUSGD
     from torch.optim import Adam as GPUAdam
 
+from megatron.core.optimizer import OptimizerConfig, _get_megatron_optimizer_based_on_param_groups
 from megatron.core.optimizer.cpu_offloading import HybridDeviceOptimizer
 
 
@@ -139,3 +142,132 @@ def test_multi_device_hybrid_optimizer(
         assert torch.allclose(
             v, ref_params[k], atol=1e-03
         ), f"Weight {k} value mismatch, max error: {(v - ref_params[k]).abs().max()}"
+
+
+@pytest.mark.skipif(torch.__version__ < '2.3.0', reason="Requires PyTorch 2.3.0 or higher")
+@pytest.mark.parametrize("offload_fraction", [0.5, 1.0])
+@pytest.mark.parametrize("model_params_dtype", [torch.bfloat16, torch.float16])
+def test_precision_aware_cpu_offload_state_dtypes(offload_fraction, model_params_dtype):
+    model_params = [
+        torch.nn.Parameter(torch.ones(32, dtype=model_params_dtype, device="cuda"))
+        for _ in range(2)
+    ]
+    config = OptimizerConfig(
+        optimizer="adam",
+        lr=1e-2,
+        fp16=model_params_dtype == torch.float16,
+        bf16=model_params_dtype == torch.bfloat16,
+        params_dtype=model_params_dtype,
+        use_distributed_optimizer=True,
+        optimizer_cpu_offload=True,
+        optimizer_offload_fraction=offload_fraction,
+        overlap_cpu_optimizer_d2h_h2d=False,
+        use_precision_aware_optimizer=True,
+        main_params_dtype=torch.float16,
+        exp_avg_dtype=torch.float16,
+        exp_avg_sq_dtype=torch.float16,
+        decoupled_weight_decay=True,
+    )
+
+    with (
+        patch(
+            "megatron.core.optimizer.DistributedOptimizer",
+            side_effect=lambda optimizer, *args, **kwargs: optimizer,
+        ),
+        patch(
+            "megatron.core.optimizer.parallel_state.get_tensor_model_parallel_group",
+            return_value=None,
+        ),
+    ):
+        optimizer = _get_megatron_optimizer_based_on_param_groups(
+            config=config, model_chunks=[], param_groups=[{"params": model_params}]
+        )
+
+    assert isinstance(optimizer, HybridDeviceOptimizer)
+    assert not optimizer.state
+    assert not optimizer.param_to_fp32_param
+    assert not optimizer.fp32_param_to_orig_param
+    initial_inner_params = {
+        model_param: optimizer.param_to_inner_param[model_param].detach().clone()
+        for model_param in model_params
+    }
+
+    for model_param in model_params:
+        model_param.decoupled_grad = torch.ones_like(model_param, dtype=torch.float32)
+    optimizer.step()
+    for model_param in model_params:
+        assert not torch.equal(
+            initial_inner_params[model_param], optimizer.param_to_inner_param[model_param]
+        )
+
+    def assert_state_dtypes():
+        devices = set()
+        for model_param in model_params:
+            master_param = optimizer.param_to_inner_param[model_param]
+            state = optimizer.state[model_param]
+            devices.add(master_param.device.type)
+            assert state["master_param"] is master_param
+            assert master_param.dtype == torch.float16
+            assert master_param.element_size() == 2
+            assert state["exp_avg"].device == master_param.device
+            assert state["exp_avg"].dtype == torch.float16
+            assert state["exp_avg_sq"].device == master_param.device
+            assert state["exp_avg_sq"].dtype == torch.float16
+
+        expected_devices = {"cpu", "cuda"} if offload_fraction == 0.5 else {"cpu"}
+        assert devices == expected_devices
+
+    assert_state_dtypes()
+
+    expected_state = {
+        model_param: {
+            key: optimizer.state[model_param][key].detach().clone()
+            for key in ("master_param", "exp_avg", "exp_avg_sq")
+        }
+        for model_param in model_params
+    }
+    state_dict = copy.deepcopy(optimizer.state_dict())
+    with torch.no_grad():
+        for model_param in model_params:
+            inner_param = optimizer.param_to_inner_param[model_param]
+            if inner_param is not model_param:
+                model_param.fill_(7)
+                inner_param.zero_()
+            optimizer.state[model_param]["exp_avg"].zero_()
+            optimizer.state[model_param]["exp_avg_sq"].zero_()
+
+    optimizer.load_state_dict(state_dict)
+    assert_state_dtypes()
+    for model_param in model_params:
+        state = optimizer.state[model_param]
+        for key in ("master_param", "exp_avg", "exp_avg_sq"):
+            torch.testing.assert_close(state[key], expected_state[model_param][key], rtol=0, atol=0)
+
+    for model_param in model_params:
+        model_param.decoupled_grad = torch.ones_like(model_param, dtype=torch.float32)
+    optimizer.step()
+    assert_state_dtypes()
+
+
+def test_precision_aware_cpu_offload_rejects_mixed_state_dtypes():
+    with pytest.raises(AssertionError, match="must use the same dtype"):
+        OptimizerConfig(
+            optimizer="adam",
+            use_distributed_optimizer=True,
+            optimizer_cpu_offload=True,
+            use_precision_aware_optimizer=True,
+            main_params_dtype=torch.float32,
+            exp_avg_dtype=torch.float16,
+            exp_avg_sq_dtype=torch.bfloat16,
+        )
+
+
+def test_hybrid_optimizer_rejects_legacy_fp32_flag_with_low_precision_dtypes():
+    with pytest.raises(AssertionError, match="param_update_in_fp32=True conflicts"):
+        HybridDeviceOptimizer(
+            [],
+            param_update_in_fp32=True,
+            main_params_dtype=torch.float16,
+            exp_avg_dtype=torch.float16,
+            exp_avg_sq_dtype=torch.float16,
+        )


### PR DESCRIPTION
## Summary

Make `HybridDeviceOptimizer` honor FP16 optimizer storage when CPU offload is enabled.

## Symptom & Reproduction

- **Symptom:** `--optimizer-cpu-offload --main-params-dtype fp16 --exp-avg-dtype fp16 --exp-avg-sq-dtype fp16` leaves all three optimizer-state tensors in FP32.
- **Reproduction:** Inspect the real HDO sub-optimizers after one Miles Qwen3-0.6B two-H200 E2E update.
- **Baseline:** Each rank reports 298,024,960 FP32 elements, or 1,192,099,840 bytes per state category.

## Root Cause

1. `_get_megatron_optimizer_based_on_param_groups` constructs `HybridDeviceOptimizer` with `param_update_in_fp32=True` and never passes the three precision-aware dtype settings.
2. `HybridDeviceOptimizer._get_sub_optimizer_param_groups` then calls `.float()` on every optimizer-side parameter copy.
3. Native `torch.optim.AdamW` initializes `exp_avg` and `exp_avg_sq` with `zeros_like(param)`, so the forced FP32 main parameter also forces both moments to FP32.
4. `OptimizerConfig` accepted mixed dtypes even though native AdamW cannot safely update them.

## Fix

- Pass the configured main-parameter and moment dtypes into `HybridDeviceOptimizer`.
- Allocate offloaded main parameters directly in their final dtype.
- Honor `pin_cpu_params` without an extra host copy.
- Use native AdamW for a low-precision partial-offload GPU slice across CPU/GPU state.
- Route `decoupled_grad` into every partial-offload GPU optimizer parameter.
- Generalize HDO's FP32-specific mappings plus load hooks to optimizer-side main parameters.
- Preserve the legacy `param_update_in_fp32` API; reject conflicting arguments.
- Reject mixed CPU-offload state dtypes explicitly; this patch supports the common FP16 or common FP32 contract.

## Verification

- `CUDA_VISIBLE_DEVICES=0 python -m pytest -q tests/unit_tests/test_optimizer_cpu_offloading.py` — 54 passed.
- Coverage includes BF16/FP16 model params under full/partial offload.
- Coverage verifies CPU/GPU updates plus a value-preserving state-dict roundtrip.
- Coverage includes continued update, mixed-dtype fail-fast, plus legacy conflict validation.
- Targeted pre-commit — black, pylint, plus isort passed.
- Miles Qwen3-0.6B 2×H200 E2E — ranks 0/1 passed after a real update.
- Each state category uses 596,049,920 bytes (568.44 MiB), exactly half the FP32 baseline.
- Final-patch rerun succeeded as Ray job `raysubmit_zs56pnMA3dtYKthc`.

## Review Focus

- Confirm the common-dtype restriction is preferable to silently accepting unsupported mixed AdamW state dtypes.
- Scrutinize partial-offload GPU AdamW selection.
- Scrutinize CPU/GPU state-device handling during load.
- Check the one-allocation pinned CPU main-parameter path.
- Check backward compatibility for `param_update_in_fp32`.
