### PR TITLE
[tml] fp32 MoE activation and combine for bf16 inference alignment

### DIFF
--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -526,6 +526,33 @@ class GroupedMLP(MegatronModule):
         pass
 
 
+class _MoEActivationInFP32(torch.autograd.Function):
+    """fp32 swiglu (x prob) between the grouped GEMMs, one round back to the params dtype."""
+
+    @staticmethod
+    def forward(ctx, fc1_out, probs, glu_offset):
+        ctx.save_for_backward(fc1_out, probs)
+        ctx.glu_offset = glu_offset
+        g, u = torch.chunk(fc1_out.float(), 2, dim=-1)
+        y = F.silu(g) * (u + glu_offset) * probs.float()
+        return y.to(fc1_out.dtype)
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        fc1_out, probs = ctx.saved_tensors
+        g, u = torch.chunk(fc1_out.float(), 2, dim=-1)
+        s = torch.sigmoid(g)
+        silu = g * s
+        go = grad_out.float() * probs.float()
+        d_g = go * (u + ctx.glu_offset) * (s + silu * (1 - s))
+        d_u = go * silu
+        d_p = None
+        if ctx.needs_input_grad[1]:
+            d_p = (grad_out.float() * silu * (u + ctx.glu_offset)).sum(-1, keepdim=True)
+            d_p = d_p.to(probs.dtype)
+        return torch.cat([d_g, d_u], dim=-1).to(fc1_out.dtype), d_p, None
+
+
 class TEGroupedMLP(MegatronModule):
     """An efficient implementation of the Experts layer using TE's GroupedLinear.
 
@@ -681,6 +708,9 @@ class TEGroupedMLP(MegatronModule):
             # Probs already applied, so reset to 1.
             permuted_probs = torch.ones_like(permuted_probs)
 
+        if self.config.moe_combine_in_fp32:
+            permuted_probs = torch.ones_like(permuted_probs)
+
         with off_interface(
             self.offload_expert_fc1, permuted_local_hidden_states, "expert_fc1"
         ) as permuted_local_hidden_states:
@@ -695,6 +725,11 @@ class TEGroupedMLP(MegatronModule):
             )
 
         def bias_act_func(intermediate_parallel, bias_parallel, permuted_probs):
+            if self.config.moe_activation_in_fp32:
+                assert bias_parallel is None and self.config.gated_linear_unit
+                return _MoEActivationInFP32.apply(
+                    intermediate_parallel, permuted_probs, self.config.glu_linear_offset
+                )
             if self.config.use_te_activation_func:
                 if bias_parallel is not None:
                     intermediate_parallel = intermediate_parallel + bias_parallel

--- a/megatron/core/transformer/moe/token_dispatcher.py
+++ b/megatron/core/transformer/moe/token_dispatcher.py
@@ -832,11 +832,17 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
             self.shared_experts.post_forward_comm()
 
         # Unpermutation 1: AlltoAll output to output
+        if self.config.moe_combine_in_fp32:
+            assert not self.config.moe_permute_fusion
+            combine_probs = self.probs
+        else:
+            combine_probs = None
         output = unpermute(
             permutated_local_input_tokens,
             self.reversed_local_input_permutation_mapping,
             restore_shape=self.hidden_shape_before_permute,
             routing_map=self.routing_map,
+            probs=combine_probs,
             fused=self.config.moe_permute_fusion,
             drop_and_pad=self.drop_and_pad,
         )

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -691,6 +691,12 @@ class TransformerConfig(ModelParallelConfig):
     improve stability especially when the number of experts is large (e.g. finegrained-moe).
     None means no changes for dtype."""
 
+    moe_activation_in_fp32: bool = False
+    """Compute the inter-GEMM swiglu in fp32 with one round back to the params dtype."""
+
+    moe_combine_in_fp32: bool = False
+    """Apply routing probs and accumulate expert outputs in fp32 with one final round."""
+
     moe_router_enable_expert_bias: bool = False
     """TopK routing with dynamic per-expert bias in the aux-loss-free load balancing strategy.
     The routing decision is based on the sum of the routing scores and the expert bias.
@@ -1921,6 +1927,21 @@ class TransformerConfig(ModelParallelConfig):
                     f"Token dispatcher type: {self.moe_token_dispatcher_type} does not support "
                     f"variable sequence length, please use alltoall dispatcher instead."
                 )
+
+        if self.moe_activation_in_fp32 or self.moe_combine_in_fp32:
+            assert not (
+                self.fp8 or getattr(self, 'fp4', None)
+            ), "moe_*_in_fp32 supports bf16/fp16 only"
+            assert (
+                not self.moe_permute_fusion
+            ), "moe_*_in_fp32 bypasses fused permute/unpermute; disable --moe-permute-fusion"
+            assert (
+                self.activation_func_clamp_value is None
+            ), "moe_*_in_fp32 is an inference-alignment mode; drop --activation-func-clamp-value"
+        if self.moe_combine_in_fp32:
+            assert (
+                self.moe_router_dtype == 'fp32'
+            ), "moe_combine_in_fp32 needs --moe-router-dtype fp32 (probs reach combine un-rounded)"
 
         if self.moe_permute_fusion:
             from megatron.core.transformer.moe.moe_utils import (


### PR DESCRIPTION
Two opt-in `TransformerConfig` knobs for MoE numerical precision on the routed-expert path, needed to match reference inference numerics for models trained with fp32 expert internals (e.g. Inkling):

- **`moe_activation_in_fp32`** — compute the inter-GEMM swiglu (× probs) in fp32 via `_MoEActivationInFP32` (custom forward/backward), with a single rounding back to the params dtype. Grouped-GEMM path only.
- **`moe_combine_in_fp32`** — carry routing probs into the combine un-rounded and accumulate expert outputs in fp32, with one final round.

Both default `False`. Guard asserts: bf16/fp16 only (no fp8/fp4), no fused permute/unpermute, and `--moe-router-dtype fp32` for combine. Existing configs are unaffected.

Rebased on latest `miles-main`; the NVMe optimizer store and checkpoint changes that used to live in this PR have been dropped from its scope.
