### PR TITLE
Restore gpt_model imports dropped in the #51 merge

### DIFF
--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -8,7 +8,7 @@ from typing import Dict, Literal, Optional
 import torch
 from torch import Tensor
 
-from megatron.core import tensor_parallel
+from megatron.core import parallel_state, tensor_parallel
 from megatron.core.config_logger import has_config_logger_enabled, log_config_to_disk
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.inference.contexts import BaseInferenceContext
@@ -29,9 +29,12 @@ from megatron.core.tensor_parallel import gather_from_sequence_parallel_region
 from megatron.core.transformer.enums import CudaGraphScope, ModelType
 from megatron.core.transformer.linear_cross_entropy import LinearCrossEntropyModule
 from megatron.core.transformer.multi_token_prediction import (
+    MTPLossAutoScaler,
+    MTPLossLoggingHelper,
     MultiTokenPredictionBlock,
     mtp_on_this_rank,
     process_mtp_loss,
+    roll_tensor,
 )
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import TransformerBlock

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -224,7 +224,10 @@ class TopKRouter(Router):
         assert not self._routing_mode_initialized
         self._routing_mode_initialized = True
 
-        mode_hash = layer_number <= self.config.dsv4_n_hash_layers
+        # MTP inner layers number from 1 (see MultiTokenPredictionLayer), which
+        # would land them inside the dsv4 hash-routed range; MTP routers were
+        # always learned-routing (they numbered past the decoder before #51).
+        mode_hash = not self.is_mtp_layer and layer_number <= self.config.dsv4_n_hash_layers
 
         self.enable_expert_bias = (
             self.config.moe_router_enable_expert_bias and not mode_hash

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -224,10 +224,7 @@ class TopKRouter(Router):
         assert not self._routing_mode_initialized
         self._routing_mode_initialized = True
 
-        # MTP inner layers number from 1 (see MultiTokenPredictionLayer), which
-        # would land them inside the dsv4 hash-routed range; MTP routers were
-        # always learned-routing (they numbered past the decoder before #51).
-        mode_hash = not self.is_mtp_layer and layer_number <= self.config.dsv4_n_hash_layers
+        mode_hash = layer_number <= self.config.dsv4_n_hash_layers
 
         self.enable_expert_bias = (
             self.config.moe_router_enable_expert_bias and not mode_hash


### PR DESCRIPTION
Restores the imports the #51 merge dropped from `gpt_model.py`. The miles-main merge kept the inline MTP-loss block in `GPTModel._postprocess` but took the branch's import list, which had dropped `parallel_state`, `roll_tensor`, `MTPLossAutoScaler` and `MTPLossLoggingHelper` — every GPT-path MTP model (qwen3.5/3.6 MTP, qwen3-next, glm4.7-flash, mimo) dies with `NameError: name 'roll_tensor' is not defined` at the first train step. First seen on [miles PR #1572 CI](https://github.com/radixark/miles/actions/runs/30975836635/job/92210473534) in `test_qwen3_5_35B_A3B_mtp/test_mtp1_spec_v2_r3.py`.

All four names still exist in `multi_token_prediction.py`; `process_mtp_loss` is imported but not called on miles-main, so there is no double-loss path. Net diff vs miles-main: +4/-1 in `gpt_model.py` (the dsv4 note below was briefly a commit here and got reverted to keep this PR minimal).

**Verified** on 8xH200 together with the paired label fix radixark/miles#2215: `test_mtp1_spec_v2_r3` (qwen3.5, MTP training + spec-v2 + R3, tp2/pp2/ep4) passes end to end with `mtp_loss` 0.39–0.49 and the R3 replay check within threshold. The qwen3.5 failure needs BOTH this PR and miles#2215 — the import restore alone gets past the NameError, then trips `MTP loss 14.57 > 1.0` from the label-convention bug fixed on the miles side.

**Known issue, deferred (not in this PR):** #51 renumbers GPT MTP inner layers from 1 instead of past the decoder, which lands them inside `layer_number <= dsv4_n_hash_layers` on dsv4 models — MTP routers were always learned-routing before. No current CI test exercises dsv4+MTP, so nothing is red today; a one-line `is_mtp_layer` guard in `router._init_routing_mode` restores the old semantics whenever dsv4+MTP training becomes a real combination.
