### PR TITLE
fix(optimizer): use expert TP group for gradient stats

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -276,6 +276,7 @@ def _get_megatron_optimizer_based_on_param_groups(
     intra_dist_opt_group: Optional[torch.distributed.ProcessGroup] = None,
     distributed_optimizer_instance_id: Optional[int] = 0,
     pg_collection: Optional[ProcessGroupCollection] = None,
+    tp_group: Optional[torch.distributed.ProcessGroup] = None,
 ) -> MegatronOptimizer:
     """Get Megatron optimizer based on parameter groups.
 
@@ -292,6 +293,9 @@ def _get_megatron_optimizer_based_on_param_groups(
             optimizer. Defaults to None.
         distributed_optimizer_instance_id (int, optional): Distributed optimizer instance. Defaults
             0.
+        tp_group (torch.distributed.ProcessGroup, optional): Tensor-parallel group used to filter
+            replicated parameters when computing gradient statistics. Defaults to the tensor model
+            parallel group.
 
     Returns:
         Instance of MegatronOptimizer.
@@ -465,10 +469,11 @@ def _get_megatron_optimizer_based_on_param_groups(
         optimizer = FP32Optimizer(optimizer, config, init_state_fn)
         setattr(optimizer, 'grad_stats_parallel_group', model_parallel_group)
 
-    if pg_collection is None or not hasattr(pg_collection, 'tp'):
-        tp_group = parallel_state.get_tensor_model_parallel_group()
-    else:
-        tp_group = pg_collection.tp
+    if tp_group is None:
+        if pg_collection is None or not hasattr(pg_collection, 'tp'):
+            tp_group = parallel_state.get_tensor_model_parallel_group()
+        else:
+            tp_group = pg_collection.tp
     # TODO(M4): plumb tp_group through optimizer constructors so this setattr disappears.
     setattr(optimizer, 'tp_group', tp_group)
 
@@ -660,6 +665,11 @@ def get_megatron_optimizer(
             param_group_id += 1
     if len(moe_param_groups) > 0:
         expt_model_parallel_rank = get_pg_rank(expt_tp_pp_group)
+        expert_tensor_parallel_group = (
+            parallel_state.get_expert_tensor_parallel_group()
+            if pg_collection is None
+            else getattr(pg_collection, 'expt_tp', None)
+        )
         # Pass Gloo process groups into optimizer only if needed.
         if use_gloo_process_groups:
             expt_data_parallel_group_gloo = intra_expt_dp_group_gloo
@@ -678,6 +688,7 @@ def get_megatron_optimizer(
                 intra_dist_opt_group=intra_dist_opt_group,
                 distributed_optimizer_instance_id=distributed_optimizer_instance_id,
                 pg_collection=pg_collection,
+                tp_group=expert_tensor_parallel_group,
             )
         )
 

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -636,6 +636,75 @@ def test_optimizer_reload_model_params():
 
 
 @pytest.mark.skipif(
+    int(os.getenv('WORLD_SIZE', '1')) < 2, reason="Test requires at least two distributed ranks"
+)
+@pytest.mark.parametrize('pg_collection_mode', ['legacy', 'explicit', 'custom_without_expt_tp'])
+def test_expert_optimizer_uses_expert_tp_group_for_grad_norm(pg_collection_mode):
+    world_size = int(os.environ['WORLD_SIZE'])
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=world_size,
+        expert_model_parallel_size=world_size,
+        expert_tensor_parallel_size=1,
+    )
+
+    try:
+
+        class ModelWithExpertParameter(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.dense = nn.Parameter(torch.ones(2, 2, device='cuda'))
+                self.expert = nn.Parameter(torch.ones(2, 2, device='cuda'))
+                self.expert.allreduce = False
+                self.ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=False)
+
+        model = ModelWithExpertParameter()
+        default_pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        if pg_collection_mode == 'legacy':
+            pg_collection = None
+            expected_dense_tp_group = default_pg_collection.tp
+            expected_expert_tp_group = default_pg_collection.expt_tp
+        elif pg_collection_mode == 'explicit':
+            pg_collection = default_pg_collection
+            expected_dense_tp_group = pg_collection.tp
+            expected_expert_tp_group = pg_collection.expt_tp
+        else:
+            pg_collection = default_pg_collection
+            del pg_collection.expt_tp
+            expected_dense_tp_group = pg_collection.tp
+            expected_expert_tp_group = pg_collection.tp
+
+        optimizer = get_megatron_optimizer(
+            OptimizerConfig(optimizer='sgd', lr=0.1),
+            [model],
+            config_overrides={},
+            use_gloo_process_groups=False,
+            pg_collection=pg_collection,
+        )
+        dense_optimizer, expert_optimizer = optimizer.chained_optimizers
+
+        assert dense_optimizer.tp_group is expected_dense_tp_group
+        assert expert_optimizer.tp_group is expected_expert_tp_group
+
+        model.dense.grad = torch.ones_like(model.dense)
+        model.expert.grad = torch.ones_like(model.expert)
+        dense_grads = dense_optimizer.get_main_grads_for_grad_norm()
+        expert_grads = expert_optimizer.get_main_grads_for_grad_norm()
+
+        if expected_dense_tp_group.rank() == 0:
+            assert len(dense_grads) == 1
+            assert dense_grads[0] is model.dense.grad
+        else:
+            assert dense_grads == []
+        if expected_expert_tp_group.rank() == 0:
+            assert len(expert_grads) == 1
+            assert expert_grads[0] is model.expert.grad
+        else:
+            assert expert_grads == []
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(
     not is_torch_min_version("2.4.0"),
     reason="torch.distributed.init_device_mesh requires torch >= 2.4.0",
 )


### PR DESCRIPTION
<!-- lint: profile=evidence-heavy -->

## Summary

Count expert gradients with expert TP ownership in standard split optimizers.

## Symptom & Reproduction

- **Symptom:** With TP4/EP4/ETP1, dense TP ranks 1–3 drop their distinct expert gradients from global statistics.
- **Reproduction:** The distributed test creates one dense parameter plus one `allreduce=False` expert parameter per rank under TP=EP=world size and ETP1. Before the fix, the expert child uses dense TP ownership, so only dense TP rank 0 retains its expert gradient.

In a DSv4 training step, the reported norm was `11.5135000849` versus the logical FP64 norm `12.2754343246`. With `clip_grad=1`, this made the clipping coefficient `6.62%` too large.

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 \
python -m torch.distributed.run --standalone --nproc_per_node=4 \
  -m pytest -xvs tests/unit_tests/test_optimizer.py \
  -k expert_optimizer_uses_expert_tp_group_for_grad_norm
```

The trigger is the standard Adam/SGD non-FSDP path with separate dense and expert child optimizers when dense TP ownership differs from ETP ownership. Backward still computes the omitted expert gradients, and the optimizer still updates those parameters; only gradient statistics and clipping use the wrong ownership set.

## Root Cause

1. `get_megatron_optimizer` creates separate dense and expert child optimizers.
2. `_get_megatron_optimizer_based_on_param_groups` assigns dense TP ownership to both children.
3. `param_is_not_tensor_parallel_duplicate` keeps replicated parameters only on that group's rank 0.
4. `TP4/EP4/ETP1` places distinct expert shards on ranks filtered as dense replicas.

`get_main_grads_for_grad_norm` and `count_zeros` both consume the child optimizer's `tp_group`, so the same ownership error affects norm computation, clipping, and zero-count logging.

## Fix

Add a child-specific `tp_group` override to `_get_megatron_optimizer_based_on_param_groups` and pass the expert tensor-parallel group when constructing the split expert optimizer. Dense children retain the dense TP group. The legacy path uses the global ETP group, an explicit `ProcessGroupCollection` uses `expt_tp`, and a custom collection without `expt_tp` retains its existing dense-TP fallback.

[NVIDIA/Megatron-LM#5916](https://github.com/NVIDIA/Megatron-LM/pull/5916) is the comprehensive upstream root fix, merged into NVIDIA `main` as `cd4afffa`. PR #80's base `d075c1e` does not contain that commit. This PR adapts only the split-optimizer ownership correction required by this fork; it does not backport #5916's gradient-synchronization, TE/native parameter-tagging, or parameter-norm changes. FSDP and Muon also remain outside this PR.

## Verification

- `test_expert_optimizer_uses_expert_tp_group_for_grad_norm` on eight ranks: `legacy` and `explicit` modes bind expert gradients to ETP1 on every rank; `custom_without_expt_tp` preserves the prior dense-TP fallback.
- DSv4 TP4/EP4/ETP1 source-fix replay: the corrected reported norm was `12.2851015996` versus FP64 logical `12.2851021737` (`4.67e-8` relative error), with zero ownership mismatches instead of 512 missing expert tensors on each of ranks 1–3.
- Qwen3-30B-A3B TP2/CP2/EP4/ETP1 integration on a Miles-compatible Megatron base whose optimizer source was byte-identical to this PR: two four-step runs completed; fixed reported norms matched independent FP64 logical reductions within `1.28e-7` relative error, while the old selector was `3.97%` to `5.49%` low across run 2.

## Review Focus

- `_get_megatron_optimizer_based_on_param_groups`: the optional override changes only the selected child's duplicate-filter ownership.
- `get_megatron_optimizer`: legacy and explicit process-group paths select ETP for the expert child without changing dense ownership.
- `custom_without_expt_tp`: the compatibility fallback is intentionally unchanged; broader expert-topology fixes from #5916 remain outside this PR.
