### PR TITLE
Publish this branch as megatron-core-miles, not megatron-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,21 @@ version = { attr = "megatron.core.package_info.__version__" }
 readme = { file = "README.md", content-type = "text/markdown" }
 
 [project]
-name = "megatron-core"
+# Published to PyPI as `megatron-core-miles`, not `megatron-core`.
+#
+# This branch carries changes Miles depends on -- the broadened
+# packages.find that exposes megatron.training / legacy / rl, and the
+# miles_megatron_plugins package. Publishing those under `megatron-core`
+# would push them at every Megatron user, so the distribution is renamed.
+# The import name is unaffected: this still provides `megatron.*`, and a
+# consumer writes `import megatron.core` exactly as before.
+#
+# Consequence to be aware of: installing this alongside upstream
+# `megatron-core` puts two distributions in the same `megatron/` tree with
+# no conflict detection from pip. Install one or the other, never both.
+name = "megatron-core-miles"
 dynamic = ["version", "readme"]
-description = "Megatron Core - a library for efficient and scalable training of transformer based models"
+description = "Megatron Core, with the changes Miles requires - a library for efficient and scalable training of transformer based models"
 requires-python = ">=3.10"
 license = { text = "Apache 2.0" }
 dependencies = ["torch>=2.6.0", "numpy", "packaging>=24.2"]


### PR DESCRIPTION
## Summary

Rename the published distribution from `megatron-core` to `megatron-core-miles`. One
`[project].name` line, plus a comment explaining why. No source or logic changes.

## Why

Miles wants to be installable with `pip install miles-rl`. That means every dependency has to
be resolvable from a package index — and Miles depends on *this branch*, not on upstream
`megatron-core`, because of two things that live here: the broadened `packages.find` that
exposes `megatron.training` / `legacy` / `rl`, and the `miles_megatron_plugins` package.

We first tried avoiding a published package altogether, by copying this tree's source into the
Miles wheel. That does not work: `megatron/core/datasets/helpers_cpp` is a **compiled
extension**, git-ignored because it is a build output, so a source copy never contains it. The
only way to deliver it is to publish a real wheel.

Publishing under the name `megatron-core` would push Miles-specific changes at every Megatron
user, so the distribution gets its own name.

The **import name does not change.** This still provides the `megatron.*` namespace and callers
write `import megatron.core` exactly as today.

## Caveat worth knowing

Installing this alongside upstream `megatron-core` puts two distributions into the same
`megatron/` directory, and pip does not detect overlapping files. Install one or the other,
never both. This is inherent to renaming a distribution that keeps its import name.

## Test plan

Built the wheel from this branch:

- Name / version: `megatron-core-miles` `0.16.0rc0`
- `Root-Is-Purelib: false`, tag `cp312-cp312-macosx_11_0_arm64` (a Linux CI build yields `manylinux`)
- **Carries the compiled extension:** `megatron/core/datasets/helpers_cpp.cpython-312-darwin.so`
- Contents: `megatron/core` 368 files, `megatron/training` 31, `megatron/legacy` 49,
  `miles_megatron_plugins` 15

## For whoever wires up the release workflow

`setup.py` declares the extension with `optional=True`. A failed compile is therefore **silently
skipped** and setuptools still produces a wheel — one that imports fine right up until something
touches the dataset helpers. The release job must assert the `.so` is present rather than trust a
green build.
