### PR TITLE
[optimizer] Fix LayerWise expert ownership

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -6,6 +6,7 @@ import inspect
 import io
 import os
 import pickle
+import re
 import warnings
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
@@ -77,6 +78,31 @@ except ImportError:
         HAVE_TE = False
 
 _TE_CONFIG_TYPE_KEY = "transformer_engine_config_type"
+_EXPERT_PARAMETER_NAME_PATTERN = re.compile(r"(weight|bias)\d*")
+
+
+def _set_expert_parameter_attributes(
+    module: torch.nn.Module,
+    parallel_mode: Optional[str],
+    use_expert_pgs: bool,
+    partition_stride: int = 1,
+) -> None:
+    """Route expert gradients and restore TP metadata hidden from TE."""
+    for name, param in module.named_parameters(recurse=False):
+        param.allreduce = not use_expert_pgs
+
+        name_match = _EXPERT_PARAMETER_NAME_PATTERN.fullmatch(name)
+        parameter_kind = name_match.group(1) if name_match else None
+        is_weight = parameter_kind == "weight"
+        is_bias = parameter_kind == "bias"
+        is_partitioned = parallel_mode in ("column", "row") and (
+            is_weight or (parallel_mode == "column" and is_bias)
+        )
+        if is_weight or is_bias:
+            param.tensor_model_parallel = is_partitioned
+        if is_partitioned:
+            param.partition_dim = 1 if parallel_mode == "row" else 0
+            param.partition_stride = partition_stride
 
 
 class TransformerEngineConfigType(enum.Enum):
@@ -588,6 +614,10 @@ class TELinear(te.pytorch.Linear):
             tp_size = get_pg_size(tp_group)
 
         self.expert_parallel = self.config.expert_model_parallel_size > 1
+        use_expert_pgs = is_expert and (
+            self.expert_parallel
+            or self.config.expert_tensor_parallel_size != self.config.tensor_model_parallel_size
+        )
         if is_expert:
             rng_tracker_name = get_expert_parallel_rng_tracker_name()
         else:
@@ -640,10 +670,10 @@ class TELinear(te.pytorch.Linear):
 
         for param in self.parameters():
             setattr(param, "parallel_mode", parallel_mode)
-            if is_expert:
-                # Reduce the gradient on the expert_data_parallel group for expert linear layers
-                setattr(param, "allreduce", not self.expert_parallel)
-            else:
+        if is_expert:
+            _set_expert_parameter_attributes(self, parallel_mode, use_expert_pgs)
+        else:
+            for param in self.parameters():
                 # Reduce the gradient on DP group
                 setattr(param, "allreduce", True)
                 if parallel_mode == "duplicated":
@@ -1014,6 +1044,15 @@ class TEColumnParallelLinear(TELinear):
                     self.bias.zero_()
                 setattr(self.bias, "allreduce", True)
 
+        if is_expert:
+            use_expert_pgs = (
+                config.expert_model_parallel_size > 1
+                or config.expert_tensor_parallel_size != config.tensor_model_parallel_size
+            )
+            _set_expert_parameter_attributes(
+                self, "column", use_expert_pgs, partition_stride=stride
+            )
+
     def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
         """Sharding along axis 0, bias sharded"""
         state_dict = self.state_dict(prefix="", keep_vars=True)
@@ -1113,6 +1152,13 @@ class TERowParallelLinear(TELinear):
                     self.bias.zero_()
                 setattr(self.bias, "allreduce", True)
                 setattr(self.bias, "sequence_parallel", config.sequence_parallel)
+
+        if is_expert:
+            use_expert_pgs = (
+                config.expert_model_parallel_size > 1
+                or config.expert_tensor_parallel_size != config.tensor_model_parallel_size
+            )
+            _set_expert_parameter_attributes(self, "row", use_expert_pgs)
 
     def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
         """Sharding along axis 1, bias not sharded"""
@@ -1560,6 +1606,10 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
             extra_kwargs["ub_name"] = tp_comm_buffer_name
 
             self.expert_parallel = self.config.expert_model_parallel_size > 1
+            use_expert_pgs = is_expert and (
+                self.expert_parallel
+                or self.config.expert_tensor_parallel_size != self.config.tensor_model_parallel_size
+            )
             if is_expert:
                 extra_kwargs["rng_tracker_name"] = get_expert_parallel_rng_tracker_name()
 
@@ -1575,6 +1625,7 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
             tp_group_for_te = tp_group
 
             self.explicit_expert_comm = is_expert and (tp_size > 1 or self.expert_parallel)
+            original_parallel_mode = parallel_mode
 
             if self.explicit_expert_comm:
                 if parallel_mode == "column":
@@ -1603,8 +1654,7 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
                 **extra_kwargs,
             )
             self.te_quant_params: Optional[TEQuantizationParams] = None
-            for param in self.parameters():
-                setattr(param, "allreduce", not (is_expert and self.expert_parallel))
+            _set_expert_parameter_attributes(self, original_parallel_mode, use_expert_pgs)
 
             def merge_extra_states(
                 self,

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -467,10 +467,15 @@ def _get_megatron_optimizer_based_on_param_groups(
 
     if pg_collection is None or not hasattr(pg_collection, 'tp'):
         tp_group = parallel_state.get_tensor_model_parallel_group()
+        expert_tp_group = (
+            parallel_state.get_expert_tensor_parallel_group(check_initialized=False) or tp_group
+        )
     else:
         tp_group = pg_collection.tp
-    # TODO(M4): plumb tp_group through optimizer constructors so this setattr disappears.
+        expert_tp_group = getattr(pg_collection, 'expt_tp', None) or tp_group
+    # TODO(M4): plumb TP groups through optimizer constructors so these setattrs disappear.
     setattr(optimizer, 'tp_group', tp_group)
+    setattr(optimizer, 'expert_tp_group', expert_tp_group)
 
     return optimizer
 

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -182,6 +182,7 @@ def count_zeros_fp32(
     grad_stats_parallel_group: torch.distributed.ProcessGroup,
     use_decoupled_grad: bool = False,
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    expert_tp_group: Optional[torch.distributed.ProcessGroup] = None,
 ) -> float:
     """Counts the number of zeros in gradients associated with the passed-in list of
     parameters.
@@ -219,7 +220,9 @@ def count_zeros_fp32(
         grad_attr = "decoupled_grad" if use_decoupled_grad else "grad"
         grad_not_none = hasattr(param, grad_attr) and getattr(param, grad_attr) is not None
         is_not_shared = param_is_not_shared(param)
-        is_not_tp_duplicate = param_is_not_tensor_parallel_duplicate(param, tp_group=tp_group)
+        is_not_tp_duplicate = param_is_not_tensor_parallel_duplicate(
+            param, tp_group=tp_group, expert_tp_group=expert_tp_group
+        )
         if grad_not_none and is_not_shared and is_not_tp_duplicate:
             grad_obj = getattr(param, grad_attr)
             data_parallel_group = get_data_parallel_group_if_dtensor(grad_obj, data_parallel_group)

--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -80,6 +80,14 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
                     opt, config, None, init_state_fn_list[i] if init_state_fn_list else None
                 )
 
+        self.tp_group = self.pg_collection.tp
+        self.expert_tp_group = getattr(self.pg_collection, 'expt_tp', None) or self.tp_group
+        for optimizer in optimizers:
+            # Child optimizers filter TP replicas when collecting gradients for
+            # the world-reduced LayerWise gradient statistics.
+            optimizer.tp_group = self.tp_group
+            optimizer.expert_tp_group = self.expert_tp_group
+
         super().__init__(optimizers)
 
         # TODO(kunlun, deyuf): potential future perf optimization
@@ -95,15 +103,17 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         # example of 4 ranks and 10 parameters p0-p9 after sorting, then dp_cp_params_list will be
         # [[p0, p7, p8], [p1, p6, p9], [p2, p5], [p3, p4]]
 
-        # simplify when dp_cp group size is 1
-        if get_pg_size(self.pg_collection.dp_cp) == 1:
+        dp_cp_size = get_pg_size(self.pg_collection.dp_cp)
+        expt_dp_size = get_pg_size(self.pg_collection.expt_dp)
+
+        # Dense and expert parameters use independent data-parallel ownership
+        # domains. Only skip sharding when neither domain has replicas.
+        if dp_cp_size == 1 and expt_dp_size == 1:
             self.dp_cp_params_list = None
             self.expt_dp_params_list = None
             return
 
         dp_cp_idx, expt_dp_idx = 0, 0
-        dp_cp_size = get_pg_size(self.pg_collection.dp_cp)
-        expt_dp_size = get_pg_size(self.pg_collection.expt_dp)
         # create ping-pong style loop so memory is more balanced
         dp_cp_loop = list(range(dp_cp_size)) + list(range(dp_cp_size))[::-1]
         expt_dp_loop = list(range(expt_dp_size)) + list(range(expt_dp_size))[::-1]
@@ -139,8 +149,11 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         for groups, params in zip(param_groups, param_groups_this_rank):
             groups["params"] = params
 
-        # simplify when expt_dp group size is 1 or expert parallel is off
-        if expt_dp_size == 1 or len(self.expt_dp_params_list[0]) == 0:
+        # Dense and expert all-gathers are independent. A singleton ownership
+        # domain or a domain with no parameters needs no synchronization.
+        if dp_cp_size == 1 or not any(self.dp_cp_params_list):
+            self.dp_cp_params_list = None
+        if expt_dp_size == 1 or not any(self.expt_dp_params_list):
             self.expt_dp_params_list = None
 
     @torch.no_grad()
@@ -149,9 +162,15 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
 
         # helper function to flatten local params, allgather, unflatten and copy to model params
         def _allgather_helper(params_list, group):
-            # flatten this rank's params and create empty tensor output list
-            device = params_list[0][0].device
-            dtype = params_list[0][0].dtype
+            flat_sizes = [sum(p.numel() for p in params) for params in params_list]
+            if not any(flat_sizes):
+                return
+
+            # The first ownership shard may legitimately be empty (for example,
+            # a pure-expert optimizer with no dense parameters).
+            prototype = next(p for params in params_list for p in params)
+            device = prototype.device
+            dtype = prototype.dtype
             rank = get_pg_rank(group)
             # for rank without params create empty tensor and participate in allgather
             src = (
@@ -159,10 +178,7 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
                 if len(params_list[rank]) > 0
                 else torch.empty(0, device=device, dtype=dtype)
             )
-            output_list = [
-                torch.empty(sum([p.numel() for p in params]), device=device, dtype=dtype)
-                for params in params_list
-            ]
+            output_list = [torch.empty(size, device=device, dtype=dtype) for size in flat_sizes]
             # single all_gather_v to collect all updated params
             torch.distributed.all_gather(output_list, src, group=group)
             # unflatten and copy gathered params for each rank i
@@ -185,18 +201,16 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
     def broadcast_params(self):
         """All rank broadcast updated local params."""
         # Broadcast linear layer weights to all other ranks. Kept as reference test.
-        if self.dp_cp_params_list is None:
-            return
-        for i, params in enumerate(self.dp_cp_params_list):
-            src_global_rank = torch.distributed.get_global_rank(self.pg_collection.dp_cp, i)
-            for p in params:
-                torch.distributed.broadcast(p, src_global_rank, self.pg_collection.dp_cp)
-        if self.expt_dp_params_list is None:
-            return
-        for i, params in enumerate(self.expt_dp_params_list):
-            src_global_rank = torch.distributed.get_global_rank(self.pg_collection.expt_dp, i)
-            for p in params:
-                torch.distributed.broadcast(p, src_global_rank, self.pg_collection.expt_dp)
+        if self.dp_cp_params_list is not None:
+            for i, params in enumerate(self.dp_cp_params_list):
+                src_global_rank = torch.distributed.get_global_rank(self.pg_collection.dp_cp, i)
+                for p in params:
+                    torch.distributed.broadcast(p, src_global_rank, self.pg_collection.dp_cp)
+        if self.expt_dp_params_list is not None:
+            for i, params in enumerate(self.expt_dp_params_list):
+                src_global_rank = torch.distributed.get_global_rank(self.pg_collection.expt_dp, i)
+                for p in params:
+                    torch.distributed.broadcast(p, src_global_rank, self.pg_collection.expt_dp)
 
     @torch.no_grad()
     def get_grad_norm(self):
@@ -216,6 +230,8 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
             params,
             grad_stats_parallel_group=None,
             use_decoupled_grad=self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8,
+            tp_group=self.tp_group,
+            expert_tp_group=self.expert_tp_group,
         )
 
     @torch.no_grad()

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -154,7 +154,9 @@ class MegatronOptimizer(ABC):
             grad_not_none = grad is not None
             is_not_shared = param_is_not_shared(param)
             is_not_tp_duplicate = tensor_parallel.param_is_not_tensor_parallel_duplicate(
-                param, getattr(self, 'tp_group', None)
+                param,
+                tp_group=getattr(self, 'tp_group', None),
+                expert_tp_group=getattr(self, 'expert_tp_group', None),
             )
             is_not_witness = not getattr(param, "_is_witness_param", False)
             if grad_not_none and is_not_shared and is_not_tp_duplicate and is_not_witness:
@@ -229,6 +231,7 @@ class MegatronOptimizer(ABC):
             grad_stats_parallel_group=self.get_grad_stats_parallel_group(),
             use_decoupled_grad=self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8,
             tp_group=getattr(self, 'tp_group', None),
+            expert_tp_group=getattr(self, 'expert_tp_group', None),
         )
 
     @abstractmethod
@@ -675,6 +678,8 @@ class Float16OptimizerWithFloat16Params(MixedPrecisionOptimizer):
                             main_param = param.detach().clone().float()
                             # Copy tensor model parallel attributes.
                             tensor_parallel.copy_tensor_model_parallel_attributes(main_param, param)
+                            if hasattr(param, 'allreduce'):
+                                main_param.allreduce = param.allreduce
                             if hasattr(param, 'shared'):
                                 main_param.shared = param.shared
                             # Replace the optimizer params with the new fp32 copy.
@@ -1296,6 +1301,8 @@ class ChainedOptimizer(MegatronOptimizer):
                 params,
                 grad_stats_parallel_group=self.get_grad_stats_parallel_group(),
                 use_decoupled_grad=self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8,
+                tp_group=getattr(self.chained_optimizers[0], 'tp_group', None),
+                expert_tp_group=getattr(self.chained_optimizers[0], 'expert_tp_group', None),
             )
         else:
             num_zeros_in_grad = 0

--- a/megatron/core/post_training/modelopt/layers.py
+++ b/megatron/core/post_training/modelopt/layers.py
@@ -145,7 +145,12 @@ class Linear(torch.nn.Linear):
         for param in self.parameters():
             if is_expert:
                 # Reduce the gradient on the expert_data_parallel group for expert linear layers
-                setattr(param, "allreduce", self.config.expert_model_parallel_size == 1)
+                use_expert_groups = (
+                    self.config.expert_model_parallel_size > 1
+                    or self.config.expert_tensor_parallel_size
+                    != self.config.tensor_model_parallel_size
+                )
+                setattr(param, "allreduce", not use_expert_groups)
             else:
                 # Reduce the gradient on DP group
                 setattr(param, "allreduce", True)

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -982,6 +982,10 @@ class ColumnParallelLinear(torch.nn.Module):
         world_size = get_pg_size(self.tp_group)
         rank = get_pg_rank(self.tp_group)
         self.explicit_expert_comm = self.is_expert and (world_size > 1 or self.expert_parallel)
+        use_expert_pgs = self.is_expert and (
+            self.expert_parallel
+            or self.config.expert_tensor_parallel_size != self.config.tensor_model_parallel_size
+        )
         self.output_size_per_partition = divide(output_size, world_size)
 
         # Parameters.
@@ -1034,7 +1038,7 @@ class ColumnParallelLinear(torch.nn.Module):
                         tensor=self.weight, is_parallel=True, dim=0, stride=stride
                     )
 
-            setattr(self.weight, "allreduce", not (self.is_expert and self.expert_parallel))
+            setattr(self.weight, "allreduce", not use_expert_pgs)
         else:
             self.weight = None
 
@@ -1056,7 +1060,7 @@ class ColumnParallelLinear(torch.nn.Module):
                 # Always initialize bias to zero.
                 with torch.no_grad():
                     self.bias.zero_()
-            setattr(self.bias, "allreduce", not (self.is_expert and self.expert_parallel))
+            setattr(self.bias, "allreduce", not use_expert_pgs)
         else:
             self.register_parameter("bias", None)
 
@@ -1367,7 +1371,11 @@ class RowParallelLinear(torch.nn.Module):
                 set_tensor_model_parallel_attributes(
                     tensor=self.weight, is_parallel=True, dim=1, stride=stride
                 )
-        setattr(self.weight, "allreduce", not (self.is_expert and self.expert_parallel))
+        use_expert_pgs = self.is_expert and (
+            self.expert_parallel
+            or self.config.expert_tensor_parallel_size != self.config.tensor_model_parallel_size
+        )
+        setattr(self.weight, "allreduce", not use_expert_pgs)
 
         if bias:
             if config.use_cpu_initialization:
@@ -1385,7 +1393,7 @@ class RowParallelLinear(torch.nn.Module):
                 # Always initialize bias to zero.
                 with torch.no_grad():
                     self.bias.zero_()
-            setattr(self.bias, "allreduce", not (self.is_expert and self.expert_parallel))
+            setattr(self.bias, "allreduce", not use_expert_pgs)
             setattr(self.bias, "sequence_parallel", self.sequence_parallel)
         else:
             self.register_parameter("bias", None)

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -27,10 +27,10 @@ from megatron.core.utils import (
     make_tp_sharded_tensor_for_checkpoint,
     prepare_input_tensors_for_wgrad_compute,
 )
+from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
 
 from ..dist_checkpointing.mapping import ShardedStateDict
 from ..transformer.utils import make_sharded_tensors_for_checkpoint
-from miles_megatron_plugins.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
 from .mappings import (
     copy_to_tensor_model_parallel_region,
     gather_from_sequence_parallel_region,
@@ -87,11 +87,17 @@ except:
     dist_reduce_scatter_func = torch.distributed._reduce_scatter_base
 
 
-def param_is_not_tensor_parallel_duplicate(param, tp_group=None):
-    """Returns true if the passed-in parameter is not a duplicate parameter
-    on another TP rank."""
+def param_is_not_tensor_parallel_duplicate(param, tp_group=None, expert_tp_group=None):
+    """Return whether a parameter contributes a unique model-parallel shard.
+
+    Parameters reduced over expert data-parallel groups use the expert
+    tensor-parallel group for duplicate filtering. Other parameters use the
+    regular tensor-parallel group.
+    """
     if hasattr(param, "tensor_model_parallel") and param.tensor_model_parallel:
         return True
+    if not getattr(param, "allreduce", True) and expert_tp_group is not None:
+        tp_group = expert_tp_group
     # Prefer provided tp_group when available (new explicit path).
     if tp_group is not None:
         return tp_group.rank() == 0

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -217,8 +217,12 @@ class GroupedMLP(MegatronModule):
                 set_tensor_model_parallel_attributes(
                     tensor=self.weight2, is_parallel=True, dim=0, stride=1
                 )
-        setattr(self.weight1, 'allreduce', not self.expert_parallel)
-        setattr(self.weight2, 'allreduce', not self.expert_parallel)
+        use_expert_pgs = (
+            self.expert_parallel
+            or self.config.expert_tensor_parallel_size != self.config.tensor_model_parallel_size
+        )
+        setattr(self.weight1, 'allreduce', not use_expert_pgs)
+        setattr(self.weight2, 'allreduce', not use_expert_pgs)
 
         def remove_extra_states_check(self, incompatible_keys):
             """

--- a/tests/unit_tests/distributed/test_grad_sync_with_expert_parallel.py
+++ b/tests/unit_tests/distributed/test_grad_sync_with_expert_parallel.py
@@ -182,7 +182,8 @@ def test_grad_sync(
         non_ep_expected_grad_data_value_after_collective /= (
             parallel_state.get_data_parallel_world_size()
         )
-    if ep_size > 1:
+    uses_expert_topology = ep_size > 1 or etp_size != 1
+    if uses_expert_topology:
         # For MoE models with exper parallelism, each expert will receive tokens from EPxETP
         # times batches, such that the expert gradient will be EPxETP times after backward,
         # and the expected gradient after collective should be 1.0 as same as dense params.

--- a/tests/unit_tests/post_training/test_modelopt_module_spec.py
+++ b/tests/unit_tests/post_training/test_modelopt_module_spec.py
@@ -19,6 +19,7 @@ from megatron.core.post_training.modelopt.gpt.model_specs import get_gpt_modelop
 from megatron.core.post_training.modelopt.gpt.state_dict_hooks import (
     mcore_gpt_load_te_state_dict_pre_hook,
 )
+from megatron.core.post_training.modelopt.layers import Linear as ModelOptLinear
 from megatron.core.post_training.modelopt.mamba.model_specs import get_mamba_stack_modelopt_spec
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
@@ -223,6 +224,38 @@ class TestModelOptMambaModel(TestModelOptGPTModel):
             max_sequence_length=4,
             hybrid_override_pattern="M*-",
         )
+
+
+def test_modelopt_expert_linear_uses_expert_topology_metadata():
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=8,
+        num_attention_heads=2,
+        tensor_model_parallel_size=2,
+        expert_model_parallel_size=1,
+        expert_tensor_parallel_size=1,
+        use_cpu_initialization=True,
+    )
+
+    expert_linear = ModelOptLinear(
+        input_size=8,
+        output_size=8,
+        config=config,
+        init_method=config.init_method,
+        bias=True,
+        is_expert=True,
+    )
+    dense_linear = ModelOptLinear(
+        input_size=8,
+        output_size=8,
+        config=config,
+        init_method=config.init_method,
+        bias=True,
+        is_expert=False,
+    )
+
+    assert all(param.allreduce is False for param in expert_linear.parameters())
+    assert all(param.allreduce is True for param in dense_linear.parameters())
 
 
 def test_get_gpt_modelopt_spec_interface():

--- a/tests/unit_tests/tensor_parallel/test_tp_attrs_without_init.py
+++ b/tests/unit_tests/tensor_parallel/test_tp_attrs_without_init.py
@@ -1,6 +1,11 @@
 import pytest
 import torch
 
+from megatron.core.extensions.transformer_engine import (
+    HAVE_TE,
+    TEColumnParallelLinear,
+    TERowParallelLinear,
+)
 from megatron.core.tensor_parallel.layers import (
     ColumnParallelLinear,
     RowParallelLinear,
@@ -85,3 +90,87 @@ class TestTPAttributesWithoutInitialization:
         assert hasattr(w, "tensor_model_parallel") and w.tensor_model_parallel is True
         assert hasattr(w, "partition_dim") and w.partition_dim == 1
         assert hasattr(w, "partition_stride") and w.partition_stride == 1
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_expert_linear_parameters_use_expert_topology_metadata(self):
+        Utils.initialize_model_parallel(tensor_model_parallel_size=2, expert_tensor_parallel_size=1)
+        cfg = TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=4,
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+            use_cpu_initialization=True,
+            perform_initialization=False,
+        )
+
+        column = ColumnParallelLinear(
+            input_size=8,
+            output_size=8,
+            init_method=cfg.init_method,
+            bias=True,
+            config=cfg,
+            gather_output=False,
+            skip_bias_add=False,
+            is_expert=True,
+        )
+        row = RowParallelLinear(
+            input_size=8,
+            output_size=8,
+            init_method=cfg.init_method,
+            bias=True,
+            input_is_parallel=True,
+            config=cfg,
+            skip_bias_add=False,
+            is_expert=True,
+        )
+
+        for param in (*column.parameters(), *row.parameters()):
+            assert param.allreduce is False
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available() or not HAVE_TE,
+        reason="CUDA and Transformer Engine are required",
+    )
+    def test_te_expert_cpu_init_bias_uses_expert_topology_metadata(self):
+        Utils.initialize_model_parallel(tensor_model_parallel_size=2, expert_tensor_parallel_size=1)
+        cfg = TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=4,
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+            use_cpu_initialization=True,
+            perform_initialization=False,
+        )
+
+        column = TEColumnParallelLinear(
+            input_size=8,
+            output_size=8,
+            init_method=cfg.init_method,
+            bias=True,
+            config=cfg,
+            gather_output=False,
+            skip_bias_add=False,
+            is_expert=True,
+            stride=2,
+        )
+        row = TERowParallelLinear(
+            input_size=8,
+            output_size=8,
+            init_method=cfg.init_method,
+            bias=True,
+            input_is_parallel=True,
+            config=cfg,
+            skip_bias_add=False,
+            is_expert=True,
+        )
+
+        for param in (*column.parameters(), *row.parameters()):
+            assert param.allreduce is False
+        assert column.bias.tensor_model_parallel is True
+        assert column.weight.partition_stride == 2
+        assert column.bias.partition_stride == 2
+        assert row.bias.tensor_model_parallel is False

--- a/tests/unit_tests/test_layer_wise_optimizer.py
+++ b/tests/unit_tests/test_layer_wise_optimizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import os
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -11,18 +12,298 @@ from packaging.version import Version
 from megatron.core import parallel_state
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
+from megatron.core.optimizer import layer_wise_optimizer as layer_wise_optimizer_module
 from megatron.core.optimizer.layer_wise_optimizer import LayerWiseDistributedOptimizer
 from megatron.core.optimizer.optimizer import Float16OptimizerWithFloat16Params, FP32Optimizer
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.layers import param_is_not_tensor_parallel_duplicate
 from megatron.core.transformer import TransformerConfig
 from megatron.core.utils import get_pg_size
 from tests.unit_tests.test_utilities import Utils
 
-# Skip all tests in this file for LTS versions
-pytestmark = pytest.mark.skipif(
+skip_layerwise_lts = pytest.mark.skipif(
     Version(os.getenv('NVIDIA_PYTORCH_VERSION', "24.01")) <= Version("25.05"),
-    reason="Skip layer-wise optimizer for LTS test",
+    reason="Skip the legacy layer-wise optimizer suite for LTS images",
 )
+
+
+class _RankGroup:
+    """Minimal process-group stand-in for duplicate-filter tests."""
+
+    def __init__(self, rank):
+        self._rank = rank
+
+    def rank(self):
+        return self._rank
+
+
+@pytest.mark.parametrize("expert_rank", [0, 1])
+def test_shard_params_keeps_expert_plane_when_dense_dp_is_singleton(monkeypatch, expert_rank):
+    """Expert ownership must not be disabled by a singleton dense-DP group."""
+    dp_group = object()
+    expert_dp_group = object()
+    monkeypatch.setattr(
+        layer_wise_optimizer_module, "get_pg_size", lambda group: 1 if group is dp_group else 2
+    )
+    monkeypatch.setattr(
+        layer_wise_optimizer_module,
+        "get_pg_rank",
+        lambda group: 0 if group is dp_group else expert_rank,
+    )
+
+    dense_param = nn.Parameter(torch.ones(1))
+    expert_params = [nn.Parameter(torch.ones(size)) for size in (1, 2, 3)]
+    base_optimizer = torch.optim.SGD(
+        [
+            {"params": [dense_param], "is_expert_parallel": False},
+            {"params": expert_params, "is_expert_parallel": True},
+        ],
+        lr=0.1,
+    )
+    optimizer = LayerWiseDistributedOptimizer.__new__(LayerWiseDistributedOptimizer)
+    optimizer.pg_collection = SimpleNamespace(dp_cp=dp_group, expt_dp=expert_dp_group)
+
+    optimizer.shard_params([base_optimizer])
+
+    assert optimizer.dp_cp_params_list is None
+    assert optimizer.expt_dp_params_list is not None
+    owned_ids = [id(param) for shard in optimizer.expt_dp_params_list for param in shard]
+    assert sorted(owned_ids) == sorted(id(param) for param in expert_params)
+    local_ids = {id(param) for param in base_optimizer.param_groups[1]["params"]}
+    assert local_ids == {id(param) for param in optimizer.expt_dp_params_list[expert_rank]}
+    assert [id(param) for param in base_optimizer.param_groups[0]["params"]] == [id(dense_param)]
+
+
+def test_allgather_params_ignores_completely_empty_plane(monkeypatch):
+    """An ownership plane with no parameters is a valid no-op."""
+    optimizer = LayerWiseDistributedOptimizer.__new__(LayerWiseDistributedOptimizer)
+    optimizer.pg_collection = SimpleNamespace(dp_cp=object(), expt_dp=object())
+    optimizer.dp_cp_params_list = [[], []]
+    optimizer.expt_dp_params_list = None
+
+    def fail_all_gather(*args, **kwargs):
+        raise AssertionError("all_gather must not run for a completely empty plane")
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fail_all_gather)
+    optimizer.allgather_params()
+
+
+def test_allgather_params_accepts_empty_first_shard(monkeypatch):
+    """Device and dtype discovery must use the first non-empty ownership shard."""
+    group = object()
+    param = nn.Parameter(torch.zeros(3))
+    optimizer = LayerWiseDistributedOptimizer.__new__(LayerWiseDistributedOptimizer)
+    optimizer.pg_collection = SimpleNamespace(dp_cp=group, expt_dp=object())
+    optimizer.dp_cp_params_list = [[], [param]]
+    optimizer.expt_dp_params_list = None
+    monkeypatch.setattr(layer_wise_optimizer_module, "get_pg_rank", lambda _: 0)
+
+    def fake_all_gather(output_list, src, group):
+        assert src.numel() == 0
+        output_list[1].fill_(5.0)
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    optimizer.allgather_params()
+    torch.testing.assert_close(param, torch.full_like(param, 5.0))
+
+
+def test_broadcast_params_runs_expert_plane_without_dense_plane(monkeypatch):
+    """Dense and expert broadcasts are independent ownership domains."""
+    expert_group = object()
+    expert_params = [nn.Parameter(torch.tensor([1.0])), nn.Parameter(torch.tensor([2.0]))]
+    optimizer = LayerWiseDistributedOptimizer.__new__(LayerWiseDistributedOptimizer)
+    optimizer.pg_collection = SimpleNamespace(dp_cp=object(), expt_dp=expert_group)
+    optimizer.dp_cp_params_list = None
+    optimizer.expt_dp_params_list = [[expert_params[0]], [expert_params[1]]]
+    calls = []
+    monkeypatch.setattr(torch.distributed, "get_global_rank", lambda _, rank: rank + 10)
+    monkeypatch.setattr(
+        torch.distributed,
+        "broadcast",
+        lambda param, src, group: calls.append((id(param), src, group)),
+    )
+
+    optimizer.broadcast_params()
+
+    assert calls == [
+        (id(expert_params[0]), 10, expert_group),
+        (id(expert_params[1]), 11, expert_group),
+    ]
+
+
+def test_expert_parameters_use_expert_tp_duplicate_filter():
+    """Expert parameters use ETP, while ordinary parameters use dense TP."""
+    param = nn.Parameter(torch.ones(1))
+    param.tensor_model_parallel = False
+    dense_tp_group = _RankGroup(rank=0)
+    expert_tp_group = _RankGroup(rank=1)
+
+    param.allreduce = True
+    assert param_is_not_tensor_parallel_duplicate(param, dense_tp_group, expert_tp_group)
+
+    param.allreduce = False
+    assert not param_is_not_tensor_parallel_duplicate(param, dense_tp_group, expert_tp_group)
+
+    param.tensor_model_parallel = True
+    assert param_is_not_tensor_parallel_duplicate(param, dense_tp_group, expert_tp_group)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_bf16_main_parameter_preserves_expert_reduction_metadata():
+    """The FP32 optimizer master must retain expert-topology routing metadata."""
+    param = nn.Parameter(torch.ones(4, dtype=torch.bfloat16, device="cuda"))
+    param.allreduce = False
+    base_optimizer = torch.optim.SGD([param], lr=0.1)
+    config = OptimizerConfig(optimizer="sgd", lr=0.1, bf16=True)
+
+    optimizer = Float16OptimizerWithFloat16Params(base_optimizer, config, None, None)
+
+    main_param = optimizer.fp32_from_float16_groups[0][0]
+    assert main_param.allreduce is False
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or int(os.getenv("WORLD_SIZE", "1")) < 2
+    or int(os.getenv("WORLD_SIZE", "1")) % 2,
+    reason="Requires an even multi-GPU world",
+)
+class TestLayerWiseExpertTopology:
+    """Distributed regressions for independent dense-DP and expert-DP ownership."""
+
+    @pytest.fixture(autouse=True, params=["etp_split", "ep_split"])
+    def setup_and_teardown(self, request):
+        world_size = int(os.environ["WORLD_SIZE"])
+        if request.param == "etp_split":
+            tensor_parallel_size = world_size
+            self.expert_model_parallel_size = 1
+            self.expert_tensor_parallel_size = world_size // 2
+        else:
+            if world_size < 4:
+                pytest.skip("EP topology requires at least four GPUs")
+            tensor_parallel_size = world_size // 2
+            self.expert_model_parallel_size = 2
+            self.expert_tensor_parallel_size = 1
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=tensor_parallel_size,
+            expert_model_parallel_size=self.expert_model_parallel_size,
+            expert_tensor_parallel_size=self.expert_tensor_parallel_size,
+        )
+        yield
+        Utils.destroy_model_parallel()
+
+    @staticmethod
+    def _process_groups():
+        return ProcessGroupCollection.use_mpu_process_groups(["tp", "expt_tp", "dp_cp", "expt_dp"])
+
+    def _make_optimizer(self, params, clip_grad):
+        config = OptimizerConfig(
+            optimizer="sgd",
+            lr=0.1,
+            min_lr=0.0,
+            weight_decay=0.0,
+            sgd_momentum=0.0,
+            clip_grad=clip_grad,
+            log_num_zeros_in_grad=True,
+            bf16=False,
+            use_distributed_optimizer=False,
+            params_dtype=torch.float32,
+        )
+        base_optimizer = torch.optim.SGD(
+            [{"params": params, "is_expert_parallel": True}], lr=config.lr
+        )
+        optimizer = LayerWiseDistributedOptimizer(
+            [FP32Optimizer(base_optimizer, config, None)], config, self._process_groups()
+        )
+        return optimizer
+
+    @staticmethod
+    def _assert_group_replicas_equal(param, group):
+        replicas = [
+            torch.empty_like(param) for _ in range(torch.distributed.get_world_size(group=group))
+        ]
+        torch.distributed.all_gather(replicas, param, group=group)
+        for replica in replicas[1:]:
+            torch.testing.assert_close(replica, replicas[0], rtol=0, atol=0)
+
+    def test_expert_shards_have_one_edp_owner_and_exact_norm(self):
+        """Each ETP shard contributes once to norm and clipping, not once per EDP replica."""
+        expert_scale = parallel_state.get_expert_model_parallel_rank() + 1
+        param = nn.Parameter(torch.full((8,), expert_scale, dtype=torch.float32, device="cuda"))
+        param.tensor_model_parallel = True
+        param.allreduce = False
+        param.main_grad = torch.full_like(param, 3.0 * expert_scale)
+        optimizer = self._make_optimizer([param], clip_grad=1.0)
+
+        assert optimizer.dp_cp_params_list is None
+        assert optimizer.expt_dp_params_list is not None
+        local_owner_count = len(optimizer.chained_optimizers[0].get_parameters())
+        global_owner_count = torch.tensor(local_owner_count, dtype=torch.int64, device="cuda")
+        torch.distributed.all_reduce(global_owner_count)
+        expected_shards = self.expert_model_parallel_size * self.expert_tensor_parallel_size
+        assert global_owner_count.item() == expected_shards
+
+        update_successful, grad_norm, num_zeros = optimizer.step()
+
+        expert_scale_sq_sum = sum(
+            scale**2 for scale in range(1, self.expert_model_parallel_size + 1)
+        )
+        expected_norm = (
+            self.expert_tensor_parallel_size * param.numel() * 3.0**2 * expert_scale_sq_sum
+        ) ** 0.5
+        assert update_successful
+        assert grad_norm == pytest.approx(expected_norm, rel=1e-6, abs=1e-6)
+        assert num_zeros == 0
+        clip_coefficient = 1.0 / (expected_norm + 1.0e-6)
+        expected_param = torch.full_like(
+            param, expert_scale - 0.1 * 3.0 * expert_scale * clip_coefficient
+        )
+        torch.testing.assert_close(param, expected_param, rtol=1e-6, atol=1e-6)
+        self._assert_group_replicas_equal(param, optimizer.pg_collection.expt_dp)
+
+    def test_nonpartitioned_expert_params_use_expert_tp_for_stats(self):
+        """ETP replicas are deduplicated without dropping EDP-owned expert parameters."""
+        expert_scale = parallel_state.get_expert_model_parallel_rank() + 1
+        first = nn.Parameter(torch.full((8,), expert_scale, dtype=torch.float32, device="cuda"))
+        second = nn.Parameter(torch.full((8,), expert_scale, dtype=torch.float32, device="cuda"))
+        for param in (first, second):
+            param.tensor_model_parallel = False
+            param.allreduce = False
+        first_grad = torch.tensor([0, 0, 0, 0, 3, 3, 3, 3], device="cuda", dtype=torch.float32)
+        second_grad = torch.tensor([0, 0, 4, 4, 4, 4, 4, 4], device="cuda", dtype=torch.float32)
+        first_grad *= expert_scale
+        second_grad *= expert_scale
+        first.main_grad = first_grad.clone()
+        second.main_grad = second_grad.clone()
+        per_expert_norm_sq = 4 * 3.0**2 + 6 * 4.0**2
+        expert_scale_sq_sum = sum(
+            scale**2 for scale in range(1, self.expert_model_parallel_size + 1)
+        )
+        expected_norm = (expert_scale_sq_sum * per_expert_norm_sq) ** 0.5
+        optimizer = self._make_optimizer([first, second], clip_grad=expected_norm / 2.0)
+
+        local_owner_count = len(optimizer.chained_optimizers[0].get_parameters())
+        global_owner_count = torch.tensor(local_owner_count, dtype=torch.int64, device="cuda")
+        torch.distributed.all_reduce(global_owner_count)
+        expected_owned_params = (
+            2 * self.expert_model_parallel_size * self.expert_tensor_parallel_size
+        )
+        assert global_owner_count.item() == expected_owned_params
+
+        update_successful, grad_norm, num_zeros = optimizer.step()
+
+        assert update_successful
+        assert grad_norm == pytest.approx(expected_norm, rel=1e-6, abs=1e-6)
+        assert num_zeros == 6 * self.expert_model_parallel_size
+        clip_coefficient = (expected_norm / 2.0) / (expected_norm + 1.0e-6)
+        torch.testing.assert_close(
+            first, torch.full_like(first, expert_scale) - 0.1 * first_grad * clip_coefficient
+        )
+        torch.testing.assert_close(
+            second, torch.full_like(second, expert_scale) - 0.1 * second_grad * clip_coefficient
+        )
+        self._assert_group_replicas_equal(first, optimizer.pg_collection.expt_dp)
+        self._assert_group_replicas_equal(second, optimizer.pg_collection.expt_dp)
 
 
 class SimpleModel(nn.Module):
@@ -62,6 +343,7 @@ class TinyModel(nn.Module):
 @pytest.mark.skipif(
     int(os.getenv('WORLD_SIZE', '1')) == 1, reason="Multi-rank test requires WORLD_SIZE > 1"
 )
+@skip_layerwise_lts
 class TestLayerWiseOptimizer:
     """Test class for LayerWiseDistributedOptimizer with common setup code."""
 

--- a/tests/unit_tests/test_muon_optimizer.py
+++ b/tests/unit_tests/test_muon_optimizer.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import math
 import os
 
 import pytest
@@ -10,10 +11,14 @@ from packaging.version import Version
 
 from megatron.core import parallel_state
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from megatron.core.optimizer import OptimizerConfig
+from megatron.core.optimizer.layer_wise_optimizer import LayerWiseDistributedOptimizer
 from megatron.core.optimizer.muon import TensorParallelMuon, get_megatron_muon_optimizer
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.moe.moe_layer import MoELayer
 from tests.unit_tests.test_utilities import Utils
 
 # Skip all tests in this file for LTS versions
@@ -273,8 +278,6 @@ class TestMuonOptimizerMultiRank:
         )
 
         # Verify it's a LayerWiseDistributedOptimizer
-        from megatron.core.optimizer.layer_wise_optimizer import LayerWiseDistributedOptimizer
-
         assert isinstance(
             optimizer, LayerWiseDistributedOptimizer
         ), "Should return LayerWiseDistributedOptimizer"
@@ -290,6 +293,209 @@ class TestMuonOptimizerMultiRank:
 
         assert update_successful, "Optimizer step should be successful"
         assert grad_norm is not None or grad_norm is None, "Grad norm should be returned"
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or int(os.getenv("WORLD_SIZE", "1")) < 2
+    or int(os.getenv("WORLD_SIZE", "1")) % 2,
+    reason="Requires an even multi-GPU world",
+)
+def test_real_moe_ddp_layerwise_muon_expert_ownership_tp2_etp1_ep1():
+    """Production expert metadata must survive DDP, Muon, and LayerWise ownership."""
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=2, expert_model_parallel_size=1, expert_tensor_parallel_size=1
+    )
+    model_parallel_cuda_manual_seed(123)
+    try:
+        transformer_config = TransformerConfig(
+            num_layers=1,
+            hidden_size=4,
+            num_attention_heads=2,
+            ffn_hidden_size=4,
+            num_moe_experts=1,
+            moe_ffn_hidden_size=4,
+            moe_router_load_balancing_type="aux_loss",
+            moe_router_topk=1,
+            moe_router_pre_softmax=True,
+            moe_aux_loss_coeff=0.01,
+            moe_token_dispatcher_type="alltoall",
+            add_bias_linear=True,
+            sequence_parallel=True,
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+            gradient_accumulation_fusion=False,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+        )
+        layer_spec = get_gpt_layer_local_spec(num_experts=1, moe_grouped_gemm=False)
+        moe_layer = MoELayer(transformer_config, layer_spec.submodules.mlp.submodules).cuda()
+
+        expert = moe_layer.experts.local_experts[0]
+        params_by_scale = (
+            (expert.linear_fc1.weight, 1.0),
+            (expert.linear_fc1.bias, 2.0),
+            (expert.linear_fc2.bias, 3.0),
+        )
+        expert_params = [param for name, param in moe_layer.named_parameters() if "experts" in name]
+        assert expert_params
+        assert all(param.allreduce is False for param in expert_params)
+        assert not getattr(expert.linear_fc2.bias, "tensor_model_parallel", False)
+
+        moe_layer.requires_grad_(False)
+        for param, _ in params_by_scale:
+            param.requires_grad_(True)
+
+        ddp_model = DistributedDataParallel(
+            transformer_config,
+            ddp_config=DistributedDataParallelConfig(
+                grad_reduce_in_fp32=True,
+                use_distributed_optimizer=False,
+                overlap_grad_reduce=False,
+                average_in_collective=False,
+            ),
+            module=moe_layer,
+        )
+        ddp_model.broadcast_params()
+
+        assert not ddp_model.buffers
+        assert len(ddp_model.expert_parallel_buffers) == 1
+        for param, _ in params_by_scale:
+            bucket_group = ddp_model.param_to_bucket_group[param]
+            assert bucket_group in ddp_model.expert_parallel_bucket_groups
+            assert bucket_group.data_parallel_group is ddp_model.intra_expt_dp_group
+
+        expert_dp_rank = parallel_state.get_expert_data_parallel_rank(
+            partial_expert_data_parallel=True
+        )
+        for param, scale in params_by_scale:
+            param.main_grad.fill_(scale * (expert_dp_rank + 1))
+        ddp_model.finish_grad_sync()
+
+        expert_dp_size = ddp_model.expt_dp_group.size()
+        data_parallel_size = ddp_model.dp_cp_group.size()
+        reduced_gradient_base = expert_dp_size * (expert_dp_size + 1) / 2 / data_parallel_size
+        for param, scale in params_by_scale:
+            torch.testing.assert_close(
+                param.main_grad,
+                torch.full_like(param.main_grad, scale * reduced_gradient_base),
+                rtol=0,
+                atol=0,
+            )
+
+        expected_norm = reduced_gradient_base * math.sqrt(
+            sum(scale**2 * param.numel() for param, scale in params_by_scale)
+        )
+        clip_grad = expected_norm / 2
+        optimizer_config = OptimizerConfig(
+            optimizer="muon",
+            lr=0.1,
+            min_lr=0.0,
+            weight_decay=0.0,
+            bf16=True,
+            use_distributed_optimizer=False,
+            clip_grad=clip_grad,
+            log_num_zeros_in_grad=True,
+            muon_momentum=0.0,
+            muon_use_nesterov=False,
+            muon_num_ns_steps=1,
+            muon_scale_mode="spectral",
+            muon_tp_mode="duplicated",
+        )
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+            ["tp", "expt_tp", "dp_cp", "expt_dp"]
+        )
+        optimizer = get_megatron_muon_optimizer(
+            config=optimizer_config,
+            model_chunks=[ddp_model],
+            use_gloo_process_groups=True,
+            layer_wise_distributed_optimizer=True,
+            pg_collection=pg_collection,
+        )
+
+        assert isinstance(optimizer, LayerWiseDistributedOptimizer)
+        assert optimizer.dp_cp_params_list is None
+        assert optimizer.expt_dp_params_list is not None
+        sharded_param_ids = [
+            id(param) for shard in optimizer.expt_dp_params_list for param in shard
+        ]
+        expected_param_ids = [id(param) for param, _ in params_by_scale]
+        assert sorted(sharded_param_ids) == sorted(expected_param_ids)
+
+        for child in optimizer.chained_optimizers:
+            for group in child.param_groups:
+                if group["params"]:
+                    assert group["is_expert_parallel"] is True
+
+        local_owner_count = sum(
+            len(child.get_parameters()) for child in optimizer.chained_optimizers
+        )
+        global_owner_count = torch.tensor(local_owner_count, dtype=torch.int64, device="cuda")
+        torch.distributed.all_reduce(global_owner_count)
+        assert global_owner_count.item() == len(params_by_scale)
+
+        muon_children = [
+            child
+            for child in optimizer.chained_optimizers
+            if isinstance(getattr(child, "optimizer", None), TensorParallelMuon)
+        ]
+        assert len(muon_children) == 1
+        muon = muon_children[0].optimizer
+        muon.scaled_orthogonalize_fn = lambda grad, tp_group, partition_dim=None: grad
+
+        owned_master_by_model = {}
+        for child in optimizer.chained_optimizers:
+            if not hasattr(child, "float16_groups"):
+                continue
+            for model_group, master_group in zip(
+                child.float16_groups, child.fp32_from_float16_groups
+            ):
+                for model_param, master_param in zip(model_group, master_group):
+                    owned_master_by_model[id(model_param)] = master_param
+
+        model_before = {id(param): param.detach().clone() for param, _ in params_by_scale}
+        master_before = {
+            param_id: master.detach().clone() for param_id, master in owned_master_by_model.items()
+        }
+        update_successful, grad_norm, num_zeros = optimizer.step()
+
+        assert update_successful
+        assert grad_norm == pytest.approx(expected_norm, rel=1e-6, abs=1e-6)
+        assert num_zeros == 0
+        clip_coefficient = clip_grad / (expected_norm + 1.0e-6)
+        for param, _ in params_by_scale:
+            assert not torch.equal(param, model_before[id(param)])
+
+        for param, _ in params_by_scale:
+            replicas = [
+                torch.empty_like(param)
+                for _ in range(torch.distributed.get_world_size(pg_collection.expt_dp))
+            ]
+            torch.distributed.all_gather(replicas, param, group=pg_collection.expt_dp)
+            for replica in replicas[1:]:
+                torch.testing.assert_close(replica, replicas[0], rtol=0, atol=0)
+
+        for param, scale in params_by_scale:
+            master = owned_master_by_model.get(id(param))
+            if master is not None:
+                clipped_grad = scale * reduced_gradient_base * clip_coefficient
+                torch.testing.assert_close(
+                    master.grad, torch.full_like(master.grad, clipped_grad), rtol=1e-6, atol=1e-6
+                )
+
+        weight = expert.linear_fc1.weight
+        weight_master = owned_master_by_model.get(id(weight))
+        if weight_master is not None:
+            clipped_weight_grad = reduced_gradient_base * clip_coefficient
+            torch.testing.assert_close(
+                weight_master,
+                master_before[id(weight)] - optimizer_config.lr * clipped_weight_grad,
+                rtol=1e-6,
+                atol=1e-6,
+            )
+    finally:
+        Utils.destroy_model_parallel()
 
 
 @pytest.mark.parametrize("mode", ["duplicated", "blockwise", "distributed"])

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -1,16 +1,21 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 
+import os
+
 import pytest
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 
+from megatron.core.extensions import transformer_engine as te_ext
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_local_spec,
     get_gpt_layer_with_transformer_engine_spec,
 )
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.module import Float16Module
 from megatron.core.transformer.moe import grouped_gemm_util as gg
-from megatron.core.transformer.moe.experts import TEGroupedMLP
+from megatron.core.transformer.moe.experts import GroupedMLP, TEGroupedMLP
 from megatron.core.transformer.moe.moe_layer import MoELayer
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import is_te_min_version
@@ -21,6 +26,78 @@ from tests.unit_tests.test_utilities import Utils
 DEVICE_CAPABILITY = None
 if torch.cuda.is_available():
     DEVICE_CAPABILITY = torch.cuda.get_device_capability()
+
+
+@pytest.mark.parametrize(("parallel_mode", "partition_dim"), (("column", 0), ("row", 1)))
+def test_expert_parameter_attributes_use_expert_topology(parallel_mode, partition_dim):
+    module = nn.Module()
+    module.register_parameter("weight0", nn.Parameter(torch.empty(4, 4)))
+    module.register_parameter("bias0", nn.Parameter(torch.empty(4)))
+
+    te_ext._set_expert_parameter_attributes(
+        module, parallel_mode=parallel_mode, use_expert_pgs=True
+    )
+
+    assert module.weight0.allreduce is False
+    assert module.weight0.tensor_model_parallel is True
+    assert module.weight0.partition_dim == partition_dim
+    assert module.bias0.allreduce is False
+    assert module.bias0.tensor_model_parallel is (parallel_mode == "column")
+
+
+@pytest.mark.parametrize(
+    ("name", "is_partitioned"),
+    (
+        ("weight", True),
+        ("weight12", True),
+        ("bias", True),
+        ("bias12", True),
+        ("weight_scale", False),
+        ("bias_extra", False),
+    ),
+)
+def test_expert_parameter_attributes_match_parameter_names(name, is_partitioned):
+    module = nn.Module()
+    module.register_parameter(name, nn.Parameter(torch.empty(4)))
+
+    te_ext._set_expert_parameter_attributes(module, parallel_mode="column", use_expert_pgs=True)
+
+    param = module.get_parameter(name)
+    assert getattr(param, "tensor_model_parallel", False) is is_partitioned
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or int(os.getenv("WORLD_SIZE", "1")) < 2
+    or int(os.getenv("WORLD_SIZE", "1")) % 2
+    or not gg.grouped_gemm_is_available(),
+    reason="Requires grouped GEMM and an even multi-GPU world",
+)
+def test_legacy_grouped_mlp_uses_expert_topology_metadata():
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=2, expert_model_parallel_size=1, expert_tensor_parallel_size=1
+    )
+    try:
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            num_moe_experts=1,
+            moe_ffn_hidden_size=16,
+            add_bias_linear=False,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups(["ep", "expt_tp", "expt_dp"])
+        grouped_mlp = GroupedMLP(1, config, pg_collection)
+
+        assert grouped_mlp.weight1.allreduce is False
+        assert grouped_mlp.weight2.allreduce is False
+    finally:
+        Utils.destroy_model_parallel()
 
 
 @pytest.mark.skipif(is_te_min_version("1.9.0.dev0"), reason="Switch to TEGroupedMLP when TE>1.9.")


### PR DESCRIPTION
## Summary

Fix `LayerWiseDistributedOptimizer` when dense and expert parameters have different data-parallel ownership groups.

In the reproduced TP2 / ETP1 / EP1 / DP1 setup, `dp_cp` has one rank while `expt_dp` has two. The old singleton fast path skipped sharding entirely, leaving a full expert optimizer copy on both ranks. World-reduced gradient statistics then counted the same expert replicas twice, making the norm `sqrt(2)` too large and clipping too strong.

The fix shards dense and expert parameters independently, handles pure-expert and empty ownership shards in all-gather/broadcast, filters expert replicas with the ETP group, and preserves the required topology metadata on child optimizers and BF16 master parameters. It assumes source expert parameters are already tagged correctly and is not a full upstream backport.

## Validation

Manually tested on 4×H200 at `3d107754`:

- CPU ownership and empty-shard regressions;
- NCCL topologies: TP2 / ETP1, TP4 / ETP2 / EP1, and TP2 / ETP1 / EP2;
- full 4-GPU LayerWise suite: 21 passed per rank;
- single-GPU optimizer suite: 16 passed, 40 skipped.

The distributed tests cover unique ownership, exact norm and clipping, zero counts, parameter updates, and expert-DP replica equality.

## Related work
- NVIDIA/Megatron-LM#5916 ：already merge to upstream main 
    expert-topology correctness fix。 (on main)
- [radixark/Megatron-LM#80](https://github.com/radixark/Megatron-LM/pull/80) is the corresponding standard split-optimizer fix on `main`; this PR is the LayerWise counterpart on `miles-main`.
- [NVIDIA/Megatron-LM#1965](https://github.com/NVIDIA/Megatron-LM/pull/1965) introduced the LayerWise sharding/all-gather path later promoted to `main` in [#2241](https://github.com/NVIDIA/Megatron-LM/pull/2241). This PR fixes the singleton and empty-shard cases in that path.
- [NVIDIA/Megatron-LM#5916](https://github.com/NVIDIA/Megatron-LM/pull/5916) is the complete upstream expert-topology fix. This PR ports only the LayerWise-relevant pieces.