### PR TITLE
fix(optimizer): route ETP-only experts through expert groups

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -6,6 +6,7 @@ import inspect
 import io
 import os
 import pickle
+import re
 import warnings
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
@@ -77,6 +78,31 @@ except ImportError:
         HAVE_TE = False
 
 _TE_CONFIG_TYPE_KEY = "transformer_engine_config_type"
+_EXPERT_PARAMETER_NAME_PATTERN = re.compile(r"(weight|bias)\d*")
+
+
+def _set_expert_parameter_attributes(
+    module: torch.nn.Module,
+    parallel_mode: Optional[str],
+    use_expert_pgs: bool,
+    partition_stride: int = 1,
+) -> None:
+    """Route expert gradients and restore TP metadata hidden from TE."""
+    for name, param in module.named_parameters(recurse=False):
+        param.allreduce = not use_expert_pgs
+
+        name_match = _EXPERT_PARAMETER_NAME_PATTERN.fullmatch(name)
+        parameter_kind = name_match.group(1) if name_match else None
+        is_weight = parameter_kind == "weight"
+        is_bias = parameter_kind == "bias"
+        is_partitioned = parallel_mode in ("column", "row") and (
+            is_weight or (parallel_mode == "column" and is_bias)
+        )
+        if is_weight or is_bias:
+            param.tensor_model_parallel = is_partitioned
+        if is_partitioned:
+            param.partition_dim = 1 if parallel_mode == "row" else 0
+            param.partition_stride = partition_stride
 
 
 class TransformerEngineConfigType(enum.Enum):
@@ -588,6 +614,10 @@ class TELinear(te.pytorch.Linear):
             tp_size = get_pg_size(tp_group)
 
         self.expert_parallel = self.config.expert_model_parallel_size > 1
+        use_expert_pgs = is_expert and (
+            self.expert_parallel
+            or self.config.expert_tensor_parallel_size != self.config.tensor_model_parallel_size
+        )
         if is_expert:
             rng_tracker_name = get_expert_parallel_rng_tracker_name()
         else:
@@ -640,10 +670,10 @@ class TELinear(te.pytorch.Linear):
 
         for param in self.parameters():
             setattr(param, "parallel_mode", parallel_mode)
-            if is_expert:
-                # Reduce the gradient on the expert_data_parallel group for expert linear layers
-                setattr(param, "allreduce", not self.expert_parallel)
-            else:
+        if is_expert:
+            _set_expert_parameter_attributes(self, parallel_mode, use_expert_pgs)
+        else:
+            for param in self.parameters():
                 # Reduce the gradient on DP group
                 setattr(param, "allreduce", True)
                 if parallel_mode == "duplicated":
@@ -1014,6 +1044,15 @@ class TEColumnParallelLinear(TELinear):
                     self.bias.zero_()
                 setattr(self.bias, "allreduce", True)
 
+        if is_expert:
+            use_expert_pgs = (
+                config.expert_model_parallel_size > 1
+                or config.expert_tensor_parallel_size != config.tensor_model_parallel_size
+            )
+            _set_expert_parameter_attributes(
+                self, "column", use_expert_pgs, partition_stride=stride
+            )
+
     def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
         """Sharding along axis 0, bias sharded"""
         state_dict = self.state_dict(prefix="", keep_vars=True)
@@ -1113,6 +1152,13 @@ class TERowParallelLinear(TELinear):
                     self.bias.zero_()
                 setattr(self.bias, "allreduce", True)
                 setattr(self.bias, "sequence_parallel", config.sequence_parallel)
+
+        if is_expert:
+            use_expert_pgs = (
+                config.expert_model_parallel_size > 1
+                or config.expert_tensor_parallel_size != config.tensor_model_parallel_size
+            )
+            _set_expert_parameter_attributes(self, "row", use_expert_pgs)
 
     def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
         """Sharding along axis 1, bias not sharded"""
@@ -1560,6 +1606,10 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
             extra_kwargs["ub_name"] = tp_comm_buffer_name
 
             self.expert_parallel = self.config.expert_model_parallel_size > 1
+            use_expert_pgs = is_expert and (
+                self.expert_parallel
+                or self.config.expert_tensor_parallel_size != self.config.tensor_model_parallel_size
+            )
             if is_expert:
                 extra_kwargs["rng_tracker_name"] = get_expert_parallel_rng_tracker_name()
 
@@ -1575,6 +1625,7 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
             tp_group_for_te = tp_group
 
             self.explicit_expert_comm = is_expert and (tp_size > 1 or self.expert_parallel)
+            original_parallel_mode = parallel_mode
 
             if self.explicit_expert_comm:
                 if parallel_mode == "column":
@@ -1603,8 +1654,7 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
                 **extra_kwargs,
             )
             self.te_quant_params: Optional[TEQuantizationParams] = None
-            for param in self.parameters():
-                setattr(param, "allreduce", not (is_expert and self.expert_parallel))
+            _set_expert_parameter_attributes(self, original_parallel_mode, use_expert_pgs)
 
             def merge_extra_states(
                 self,

--- a/megatron/core/post_training/modelopt/layers.py
+++ b/megatron/core/post_training/modelopt/layers.py
@@ -145,7 +145,12 @@ class Linear(torch.nn.Linear):
         for param in self.parameters():
             if is_expert:
                 # Reduce the gradient on the expert_data_parallel group for expert linear layers
-                setattr(param, "allreduce", self.config.expert_model_parallel_size == 1)
+                use_expert_groups = (
+                    self.config.expert_model_parallel_size > 1
+                    or self.config.expert_tensor_parallel_size
+                    != self.config.tensor_model_parallel_size
+                )
+                setattr(param, "allreduce", not use_expert_groups)
             else:
                 # Reduce the gradient on DP group
                 setattr(param, "allreduce", True)

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -982,6 +982,10 @@ class ColumnParallelLinear(torch.nn.Module):
         world_size = get_pg_size(self.tp_group)
         rank = get_pg_rank(self.tp_group)
         self.explicit_expert_comm = self.is_expert and (world_size > 1 or self.expert_parallel)
+        use_expert_pgs = self.is_expert and (
+            self.expert_parallel
+            or self.config.expert_tensor_parallel_size != self.config.tensor_model_parallel_size
+        )
         self.output_size_per_partition = divide(output_size, world_size)
 
         # Parameters.
@@ -1034,7 +1038,7 @@ class ColumnParallelLinear(torch.nn.Module):
                         tensor=self.weight, is_parallel=True, dim=0, stride=stride
                     )
 
-            setattr(self.weight, "allreduce", not (self.is_expert and self.expert_parallel))
+            setattr(self.weight, "allreduce", not use_expert_pgs)
         else:
             self.weight = None
 
@@ -1056,7 +1060,7 @@ class ColumnParallelLinear(torch.nn.Module):
                 # Always initialize bias to zero.
                 with torch.no_grad():
                     self.bias.zero_()
-            setattr(self.bias, "allreduce", not (self.is_expert and self.expert_parallel))
+            setattr(self.bias, "allreduce", not use_expert_pgs)
         else:
             self.register_parameter("bias", None)
 
@@ -1367,7 +1371,11 @@ class RowParallelLinear(torch.nn.Module):
                 set_tensor_model_parallel_attributes(
                     tensor=self.weight, is_parallel=True, dim=1, stride=stride
                 )
-        setattr(self.weight, "allreduce", not (self.is_expert and self.expert_parallel))
+        use_expert_pgs = self.is_expert and (
+            self.expert_parallel
+            or self.config.expert_tensor_parallel_size != self.config.tensor_model_parallel_size
+        )
+        setattr(self.weight, "allreduce", not use_expert_pgs)
 
         if bias:
             if config.use_cpu_initialization:
@@ -1385,7 +1393,7 @@ class RowParallelLinear(torch.nn.Module):
                 # Always initialize bias to zero.
                 with torch.no_grad():
                     self.bias.zero_()
-            setattr(self.bias, "allreduce", not (self.is_expert and self.expert_parallel))
+            setattr(self.bias, "allreduce", not use_expert_pgs)
             setattr(self.bias, "sequence_parallel", self.sequence_parallel)
         else:
             self.register_parameter("bias", None)

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -217,8 +217,12 @@ class GroupedMLP(MegatronModule):
                 set_tensor_model_parallel_attributes(
                     tensor=self.weight2, is_parallel=True, dim=0, stride=1
                 )
-        setattr(self.weight1, 'allreduce', not self.expert_parallel)
-        setattr(self.weight2, 'allreduce', not self.expert_parallel)
+        use_expert_pgs = (
+            self.expert_parallel
+            or self.config.expert_tensor_parallel_size != self.config.tensor_model_parallel_size
+        )
+        setattr(self.weight1, 'allreduce', not use_expert_pgs)
+        setattr(self.weight2, 'allreduce', not use_expert_pgs)
 
         def remove_extra_states_check(self, incompatible_keys):
             """

--- a/tests/unit_tests/distributed/test_grad_sync_with_expert_parallel.py
+++ b/tests/unit_tests/distributed/test_grad_sync_with_expert_parallel.py
@@ -182,7 +182,8 @@ def test_grad_sync(
         non_ep_expected_grad_data_value_after_collective /= (
             parallel_state.get_data_parallel_world_size()
         )
-    if ep_size > 1:
+    uses_expert_topology = ep_size > 1 or etp_size != 1
+    if uses_expert_topology:
         # For MoE models with exper parallelism, each expert will receive tokens from EPxETP
         # times batches, such that the expert gradient will be EPxETP times after backward,
         # and the expected gradient after collective should be 1.0 as same as dense params.

--- a/tests/unit_tests/post_training/test_modelopt_module_spec.py
+++ b/tests/unit_tests/post_training/test_modelopt_module_spec.py
@@ -19,6 +19,7 @@ from megatron.core.post_training.modelopt.gpt.model_specs import get_gpt_modelop
 from megatron.core.post_training.modelopt.gpt.state_dict_hooks import (
     mcore_gpt_load_te_state_dict_pre_hook,
 )
+from megatron.core.post_training.modelopt.layers import Linear as ModelOptLinear
 from megatron.core.post_training.modelopt.mamba.model_specs import get_mamba_stack_modelopt_spec
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
@@ -223,6 +224,38 @@ class TestModelOptMambaModel(TestModelOptGPTModel):
             max_sequence_length=4,
             hybrid_override_pattern="M*-",
         )
+
+
+def test_modelopt_expert_linear_uses_expert_topology_metadata():
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=8,
+        num_attention_heads=2,
+        tensor_model_parallel_size=2,
+        expert_model_parallel_size=1,
+        expert_tensor_parallel_size=1,
+        use_cpu_initialization=True,
+    )
+
+    expert_linear = ModelOptLinear(
+        input_size=8,
+        output_size=8,
+        config=config,
+        init_method=config.init_method,
+        bias=True,
+        is_expert=True,
+    )
+    dense_linear = ModelOptLinear(
+        input_size=8,
+        output_size=8,
+        config=config,
+        init_method=config.init_method,
+        bias=True,
+        is_expert=False,
+    )
+
+    assert all(param.allreduce is False for param in expert_linear.parameters())
+    assert all(param.allreduce is True for param in dense_linear.parameters())
 
 
 def test_get_gpt_modelopt_spec_interface():

--- a/tests/unit_tests/tensor_parallel/test_tp_attrs_without_init.py
+++ b/tests/unit_tests/tensor_parallel/test_tp_attrs_without_init.py
@@ -1,6 +1,11 @@
 import pytest
 import torch
 
+from megatron.core.extensions.transformer_engine import (
+    HAVE_TE,
+    TEColumnParallelLinear,
+    TERowParallelLinear,
+)
 from megatron.core.tensor_parallel.layers import (
     ColumnParallelLinear,
     RowParallelLinear,
@@ -85,3 +90,87 @@ class TestTPAttributesWithoutInitialization:
         assert hasattr(w, "tensor_model_parallel") and w.tensor_model_parallel is True
         assert hasattr(w, "partition_dim") and w.partition_dim == 1
         assert hasattr(w, "partition_stride") and w.partition_stride == 1
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_expert_linear_parameters_use_expert_topology_metadata(self):
+        Utils.initialize_model_parallel(tensor_model_parallel_size=2, expert_tensor_parallel_size=1)
+        cfg = TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=4,
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+            use_cpu_initialization=True,
+            perform_initialization=False,
+        )
+
+        column = ColumnParallelLinear(
+            input_size=8,
+            output_size=8,
+            init_method=cfg.init_method,
+            bias=True,
+            config=cfg,
+            gather_output=False,
+            skip_bias_add=False,
+            is_expert=True,
+        )
+        row = RowParallelLinear(
+            input_size=8,
+            output_size=8,
+            init_method=cfg.init_method,
+            bias=True,
+            input_is_parallel=True,
+            config=cfg,
+            skip_bias_add=False,
+            is_expert=True,
+        )
+
+        for param in (*column.parameters(), *row.parameters()):
+            assert param.allreduce is False
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available() or not HAVE_TE,
+        reason="CUDA and Transformer Engine are required",
+    )
+    def test_te_expert_cpu_init_bias_uses_expert_topology_metadata(self):
+        Utils.initialize_model_parallel(tensor_model_parallel_size=2, expert_tensor_parallel_size=1)
+        cfg = TransformerConfig(
+            num_layers=1,
+            hidden_size=8,
+            num_attention_heads=4,
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+            use_cpu_initialization=True,
+            perform_initialization=False,
+        )
+
+        column = TEColumnParallelLinear(
+            input_size=8,
+            output_size=8,
+            init_method=cfg.init_method,
+            bias=True,
+            config=cfg,
+            gather_output=False,
+            skip_bias_add=False,
+            is_expert=True,
+            stride=2,
+        )
+        row = TERowParallelLinear(
+            input_size=8,
+            output_size=8,
+            init_method=cfg.init_method,
+            bias=True,
+            input_is_parallel=True,
+            config=cfg,
+            skip_bias_add=False,
+            is_expert=True,
+        )
+
+        for param in (*column.parameters(), *row.parameters()):
+            assert param.allreduce is False
+        assert column.bias.tensor_model_parallel is True
+        assert column.weight.partition_stride == 2
+        assert column.bias.partition_stride == 2
+        assert row.bias.tensor_model_parallel is False

--- a/tests/unit_tests/test_muon_optimizer.py
+++ b/tests/unit_tests/test_muon_optimizer.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import math
 import os
 
 import pytest
@@ -10,10 +11,14 @@ from packaging.version import Version
 
 from megatron.core import parallel_state
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from megatron.core.optimizer import OptimizerConfig
+from megatron.core.optimizer.layer_wise_optimizer import LayerWiseDistributedOptimizer
 from megatron.core.optimizer.muon import TensorParallelMuon, get_megatron_muon_optimizer
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.moe.moe_layer import MoELayer
 from tests.unit_tests.test_utilities import Utils
 
 # Skip all tests in this file for LTS versions
@@ -273,8 +278,6 @@ class TestMuonOptimizerMultiRank:
         )
 
         # Verify it's a LayerWiseDistributedOptimizer
-        from megatron.core.optimizer.layer_wise_optimizer import LayerWiseDistributedOptimizer
-
         assert isinstance(
             optimizer, LayerWiseDistributedOptimizer
         ), "Should return LayerWiseDistributedOptimizer"
@@ -290,6 +293,209 @@ class TestMuonOptimizerMultiRank:
 
         assert update_successful, "Optimizer step should be successful"
         assert grad_norm is not None or grad_norm is None, "Grad norm should be returned"
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or int(os.getenv("WORLD_SIZE", "1")) < 2
+    or int(os.getenv("WORLD_SIZE", "1")) % 2,
+    reason="Requires an even multi-GPU world",
+)
+def test_real_moe_ddp_layerwise_muon_expert_ownership_tp2_etp1_ep1():
+    """Production expert metadata must survive DDP, Muon, and LayerWise ownership."""
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=2, expert_model_parallel_size=1, expert_tensor_parallel_size=1
+    )
+    model_parallel_cuda_manual_seed(123)
+    try:
+        transformer_config = TransformerConfig(
+            num_layers=1,
+            hidden_size=4,
+            num_attention_heads=2,
+            ffn_hidden_size=4,
+            num_moe_experts=1,
+            moe_ffn_hidden_size=4,
+            moe_router_load_balancing_type="aux_loss",
+            moe_router_topk=1,
+            moe_router_pre_softmax=True,
+            moe_aux_loss_coeff=0.01,
+            moe_token_dispatcher_type="alltoall",
+            add_bias_linear=True,
+            sequence_parallel=True,
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+            gradient_accumulation_fusion=False,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+        )
+        layer_spec = get_gpt_layer_local_spec(num_experts=1, moe_grouped_gemm=False)
+        moe_layer = MoELayer(transformer_config, layer_spec.submodules.mlp.submodules).cuda()
+
+        expert = moe_layer.experts.local_experts[0]
+        params_by_scale = (
+            (expert.linear_fc1.weight, 1.0),
+            (expert.linear_fc1.bias, 2.0),
+            (expert.linear_fc2.bias, 3.0),
+        )
+        expert_params = [param for name, param in moe_layer.named_parameters() if "experts" in name]
+        assert expert_params
+        assert all(param.allreduce is False for param in expert_params)
+        assert not getattr(expert.linear_fc2.bias, "tensor_model_parallel", False)
+
+        moe_layer.requires_grad_(False)
+        for param, _ in params_by_scale:
+            param.requires_grad_(True)
+
+        ddp_model = DistributedDataParallel(
+            transformer_config,
+            ddp_config=DistributedDataParallelConfig(
+                grad_reduce_in_fp32=True,
+                use_distributed_optimizer=False,
+                overlap_grad_reduce=False,
+                average_in_collective=False,
+            ),
+            module=moe_layer,
+        )
+        ddp_model.broadcast_params()
+
+        assert not ddp_model.buffers
+        assert len(ddp_model.expert_parallel_buffers) == 1
+        for param, _ in params_by_scale:
+            bucket_group = ddp_model.param_to_bucket_group[param]
+            assert bucket_group in ddp_model.expert_parallel_bucket_groups
+            assert bucket_group.data_parallel_group is ddp_model.intra_expt_dp_group
+
+        expert_dp_rank = parallel_state.get_expert_data_parallel_rank(
+            partial_expert_data_parallel=True
+        )
+        for param, scale in params_by_scale:
+            param.main_grad.fill_(scale * (expert_dp_rank + 1))
+        ddp_model.finish_grad_sync()
+
+        expert_dp_size = ddp_model.expt_dp_group.size()
+        data_parallel_size = ddp_model.dp_cp_group.size()
+        reduced_gradient_base = expert_dp_size * (expert_dp_size + 1) / 2 / data_parallel_size
+        for param, scale in params_by_scale:
+            torch.testing.assert_close(
+                param.main_grad,
+                torch.full_like(param.main_grad, scale * reduced_gradient_base),
+                rtol=0,
+                atol=0,
+            )
+
+        expected_norm = reduced_gradient_base * math.sqrt(
+            sum(scale**2 * param.numel() for param, scale in params_by_scale)
+        )
+        clip_grad = expected_norm / 2
+        optimizer_config = OptimizerConfig(
+            optimizer="muon",
+            lr=0.1,
+            min_lr=0.0,
+            weight_decay=0.0,
+            bf16=True,
+            use_distributed_optimizer=False,
+            clip_grad=clip_grad,
+            log_num_zeros_in_grad=True,
+            muon_momentum=0.0,
+            muon_use_nesterov=False,
+            muon_num_ns_steps=1,
+            muon_scale_mode="spectral",
+            muon_tp_mode="duplicated",
+        )
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+            ["tp", "expt_tp", "dp_cp", "expt_dp"]
+        )
+        optimizer = get_megatron_muon_optimizer(
+            config=optimizer_config,
+            model_chunks=[ddp_model],
+            use_gloo_process_groups=True,
+            layer_wise_distributed_optimizer=True,
+            pg_collection=pg_collection,
+        )
+
+        assert isinstance(optimizer, LayerWiseDistributedOptimizer)
+        assert optimizer.dp_cp_params_list is None
+        assert optimizer.expt_dp_params_list is not None
+        sharded_param_ids = [
+            id(param) for shard in optimizer.expt_dp_params_list for param in shard
+        ]
+        expected_param_ids = [id(param) for param, _ in params_by_scale]
+        assert sorted(sharded_param_ids) == sorted(expected_param_ids)
+
+        for child in optimizer.chained_optimizers:
+            for group in child.param_groups:
+                if group["params"]:
+                    assert group["is_expert_parallel"] is True
+
+        local_owner_count = sum(
+            len(child.get_parameters()) for child in optimizer.chained_optimizers
+        )
+        global_owner_count = torch.tensor(local_owner_count, dtype=torch.int64, device="cuda")
+        torch.distributed.all_reduce(global_owner_count)
+        assert global_owner_count.item() == len(params_by_scale)
+
+        muon_children = [
+            child
+            for child in optimizer.chained_optimizers
+            if isinstance(getattr(child, "optimizer", None), TensorParallelMuon)
+        ]
+        assert len(muon_children) == 1
+        muon = muon_children[0].optimizer
+        muon.scaled_orthogonalize_fn = lambda grad, tp_group, partition_dim=None: grad
+
+        owned_master_by_model = {}
+        for child in optimizer.chained_optimizers:
+            if not hasattr(child, "float16_groups"):
+                continue
+            for model_group, master_group in zip(
+                child.float16_groups, child.fp32_from_float16_groups
+            ):
+                for model_param, master_param in zip(model_group, master_group):
+                    owned_master_by_model[id(model_param)] = master_param
+
+        model_before = {id(param): param.detach().clone() for param, _ in params_by_scale}
+        master_before = {
+            param_id: master.detach().clone() for param_id, master in owned_master_by_model.items()
+        }
+        update_successful, grad_norm, num_zeros = optimizer.step()
+
+        assert update_successful
+        assert grad_norm == pytest.approx(expected_norm, rel=1e-6, abs=1e-6)
+        assert num_zeros == 0
+        clip_coefficient = clip_grad / (expected_norm + 1.0e-6)
+        for param, _ in params_by_scale:
+            assert not torch.equal(param, model_before[id(param)])
+
+        for param, _ in params_by_scale:
+            replicas = [
+                torch.empty_like(param)
+                for _ in range(torch.distributed.get_world_size(pg_collection.expt_dp))
+            ]
+            torch.distributed.all_gather(replicas, param, group=pg_collection.expt_dp)
+            for replica in replicas[1:]:
+                torch.testing.assert_close(replica, replicas[0], rtol=0, atol=0)
+
+        for param, scale in params_by_scale:
+            master = owned_master_by_model.get(id(param))
+            if master is not None:
+                clipped_grad = scale * reduced_gradient_base * clip_coefficient
+                torch.testing.assert_close(
+                    master.grad, torch.full_like(master.grad, clipped_grad), rtol=1e-6, atol=1e-6
+                )
+
+        weight = expert.linear_fc1.weight
+        weight_master = owned_master_by_model.get(id(weight))
+        if weight_master is not None:
+            clipped_weight_grad = reduced_gradient_base * clip_coefficient
+            torch.testing.assert_close(
+                weight_master,
+                master_before[id(weight)] - optimizer_config.lr * clipped_weight_grad,
+                rtol=1e-6,
+                atol=1e-6,
+            )
+    finally:
+        Utils.destroy_model_parallel()
 
 
 @pytest.mark.parametrize("mode", ["duplicated", "blockwise", "distributed"])

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -1,16 +1,21 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 
+import os
+
 import pytest
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 
+from megatron.core.extensions import transformer_engine as te_ext
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_local_spec,
     get_gpt_layer_with_transformer_engine_spec,
 )
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.module import Float16Module
 from megatron.core.transformer.moe import grouped_gemm_util as gg
-from megatron.core.transformer.moe.experts import TEGroupedMLP
+from megatron.core.transformer.moe.experts import GroupedMLP, TEGroupedMLP
 from megatron.core.transformer.moe.moe_layer import MoELayer
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import is_te_min_version
@@ -21,6 +26,78 @@ from tests.unit_tests.test_utilities import Utils
 DEVICE_CAPABILITY = None
 if torch.cuda.is_available():
     DEVICE_CAPABILITY = torch.cuda.get_device_capability()
+
+
+@pytest.mark.parametrize(("parallel_mode", "partition_dim"), (("column", 0), ("row", 1)))
+def test_expert_parameter_attributes_use_expert_topology(parallel_mode, partition_dim):
+    module = nn.Module()
+    module.register_parameter("weight0", nn.Parameter(torch.empty(4, 4)))
+    module.register_parameter("bias0", nn.Parameter(torch.empty(4)))
+
+    te_ext._set_expert_parameter_attributes(
+        module, parallel_mode=parallel_mode, use_expert_pgs=True
+    )
+
+    assert module.weight0.allreduce is False
+    assert module.weight0.tensor_model_parallel is True
+    assert module.weight0.partition_dim == partition_dim
+    assert module.bias0.allreduce is False
+    assert module.bias0.tensor_model_parallel is (parallel_mode == "column")
+
+
+@pytest.mark.parametrize(
+    ("name", "is_partitioned"),
+    (
+        ("weight", True),
+        ("weight12", True),
+        ("bias", True),
+        ("bias12", True),
+        ("weight_scale", False),
+        ("bias_extra", False),
+    ),
+)
+def test_expert_parameter_attributes_match_parameter_names(name, is_partitioned):
+    module = nn.Module()
+    module.register_parameter(name, nn.Parameter(torch.empty(4)))
+
+    te_ext._set_expert_parameter_attributes(module, parallel_mode="column", use_expert_pgs=True)
+
+    param = module.get_parameter(name)
+    assert getattr(param, "tensor_model_parallel", False) is is_partitioned
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or int(os.getenv("WORLD_SIZE", "1")) < 2
+    or int(os.getenv("WORLD_SIZE", "1")) % 2
+    or not gg.grouped_gemm_is_available(),
+    reason="Requires grouped GEMM and an even multi-GPU world",
+)
+def test_legacy_grouped_mlp_uses_expert_topology_metadata():
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=2, expert_model_parallel_size=1, expert_tensor_parallel_size=1
+    )
+    try:
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            num_moe_experts=1,
+            moe_ffn_hidden_size=16,
+            add_bias_linear=False,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups(["ep", "expt_tp", "expt_dp"])
+        grouped_mlp = GroupedMLP(1, config, pg_collection)
+
+        assert grouped_mlp.weight1.allreduce is False
+        assert grouped_mlp.weight2.allreduce is False
+    finally:
+        Utils.destroy_model_parallel()
 
 
 @pytest.mark.skipif(is_te_min_version("1.9.0.dev0"), reason="Switch to TEGroupedMLP when TE>1.9.")


### PR DESCRIPTION
> **Depends on:** #82
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary

Route ETP-only expert parameters through expert reduction and LayerWise ownership.

## Symptom & Reproduction

- **Symptom:** At parent head `3d107754c`, TP2/ETP1/EP1 expert parameters carry `allreduce=True`, so DDP puts them in dense buffers and LayerWise uses the dense ownership plane.
- **Reproduction:** Run `NVIDIA_PYTORCH_VERSION=25.06 torchrun --standalone --nproc-per-node=2 -m pytest -q tests/unit_tests/test_muon_optimizer.py::test_real_moe_ddp_layerwise_muon_expert_ownership_tp2_etp1_ep1`; the parent behavior violates the expert-tag and expert-buffer assertions, while this commit passes them.

## Root Cause

1. `ColumnParallelLinear` derived `param.allreduce` from `EP > 1` only.
2. `DistributedDataParallel` selected dense buffers for those mislabeled parameters.
3. `_get_param_groups` propagated dense ownership into `LayerWiseDistributedOptimizer`.

## Fix

Port the producer predicate `is_expert and (EP > 1 or ETP != TP)` from [NVIDIA/Megatron-LM#5916](https://github.com/NVIDIA/Megatron-LM/pull/5916) at head `6ccd20e2005b0698e908d42db771e2f22b0281e8` across native, Transformer Engine, grouped, legacy, and ModelOpt linear layers. The TE helper also restores numbered-parameter TP metadata and preserves SwiGLU partition stride; DDP remains unchanged because it already honors `param.allreduce`.

## Verification

- `pytest -q tests/unit_tests/transformer/moe/test_grouped_mlp.py -k 'expert_parameter_attributes' tests/unit_tests/post_training/test_modelopt_module_spec.py -k 'expert_parameter_attributes or modelopt_expert_linear'`: 9 passed.
- The 2-GPU native, TE CPU-init, and ETP-only DDP collective set: 3 passed on each rank; the optional legacy `GroupedMLP` runtime case skipped because `grouped_gemm` is unavailable.
- The 2-GPU TE `stride=2` plus real MoE end-to-end set: 2 passed on each rank.
- The 8-GPU real MoE → DDP → Muon/Adam → LayerWise test: all eight ranks passed exact buffer, owner, norm, clipping, update, and EDP replica assertions.
- `git diff --check`, `isort --check-only`, and `python -m compileall -q`: passed for the changed files.

## Review Focus

- `_set_expert_parameter_attributes`: numbered weight/bias matching, row-bias replication, and `partition_stride` preservation.
- `use_expert_pgs`: identical topology semantics across every expert parameter producer.
- `test_real_moe_ddp_layerwise_muon_expert_ownership_tp2_etp1_ep1`: deterministic gradients still exercise real MoE construction, DDP collectives, optimizer grouping, ownership, clipping, and updates.
