### PR TITLE
Handle empty distributed optimizer bucket shards

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1945,6 +1945,16 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         data_parallel_world_size = self.data_parallel_group.size()
 
         state = self.get_parameter_state_dp_reshardable()
+        padding_state_template = next(
+            (
+                {k: v for k, v in tensors.items() if isinstance(v, torch.Tensor)}
+                for other_gbuf_idx in range(len(self.gbuf_ranges))
+                for other_dtype_state in state[other_gbuf_idx].values()
+                for other_bucket_state in other_dtype_state
+                for tensors in other_bucket_state
+            ),
+            None,
+        )
         # per_bucket_numel metadata is saved separately for each TPxPP domain.
         for per_bucket_key in ('per_bucket_numel', 'per_bucket_numel_unpadded'):
             key = (
@@ -1976,9 +1986,31 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         f'.gbuf_idx_{gbuf_idx}.dtype_{dtype}.bucket_idx_{bucket_idx}'
                     )
 
-                    # The global ckpt tensors must be fully covered.
-                    # We add extra empty padding if necessary
-                    assert bucket_state, 'empty bucket encountered'
+                    if not bucket_state:
+                        world_start = data_parallel_rank * gbuf_local_numel
+                        padding_numel = min(
+                            gbuf_local_numel, max(0, gbuf_world_numel_unpadded - world_start)
+                        )
+                        if padding_numel == 0:
+                            # Preserve an empty terminal shard through checkpoint loading.
+                            gbuf_range_map_for_all_buckets[bucket_idx] = LocalNonpersistentObject(
+                                bucket_state
+                            )
+                            continue
+                        assert (
+                            padding_state_template
+                        ), 'empty bucket has no optimizer state template'
+                        bucket_state.append(
+                            {
+                                **{
+                                    k: torch.empty(padding_numel, dtype=v.dtype, device=v.device)
+                                    for k, v in padding_state_template.items()
+                                },
+                                'gbuf_local_start': 0,
+                                'gbuf_local_end': padding_numel,
+                                'padding': True,
+                            }
+                        )
 
                     # Insert padding between parameter tensors to ensure full coverage as needed.
                     all_pad_tensors = {}

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -899,8 +899,9 @@ class TestDistributedOptimizer:
     @pytest.mark.parametrize(
         ('src_tp_pp', 'dest_tp_pp', 'src_bucket_pad_divisor', 'dest_bucket_pad_divisor'),
         [
+            # Large bucket padding can leave some DP ranks with no unpadded slice.
+            ((1, 1), (1, 1), 8 * 1024, 8 * 1024),
             # PP must be decreasing
-            # Note: PP must be > 1 if TP <= 2 because of empty buckets otherwise
             ((1, 2), (1, 2), 8 * 7, 8 * 5),
             ((2, 4), (2, 4), 128, 128),
             ((8, 1), (8, 1), 8, 4 * 11),


### PR DESCRIPTION
## Summary

- emit padding shards when an empty rank interval lies inside the unpadded bucket
- represent empty terminal distributed-optimizer shards as local nonpersistent state
- derive padding state from an authoritative resident optimizer tensor and retain validation when no state schema is available
- cover save/load round trips when large bucket padding leaves DP ranks without a parameter slice