### PR TITLE
Restore DeepSeek V4 freeze arguments

### DIFF
--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -540,7 +540,7 @@ def finalize_model_grads(
     if config.timers is not None:
         config.timers('embedding-grads-all-reduce').stop()
 
-    if config.moe_router_enable_expert_bias:
+    if config.moe_router_enable_expert_bias and not config.freeze_e_score_correction_bias:
         if pg_collection is None:
             tp_dp_cp_group = parallel_state.get_tensor_and_data_parallel_group(
                 with_context_parallel=True

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -88,6 +88,11 @@ class Router(ABC, MegatronModule):
         self.calculate_per_token_loss = self.config.calculate_per_token_loss
         self.reset_parameters()
 
+        if self.config.moe_router_freeze_gate:
+            self.weight.requires_grad = False
+            if self.bias is not None:
+                self.bias.requires_grad = False
+
     def reset_parameters(self):
         """Reset the router parameters."""
         if self.config.perform_initialization:

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -124,6 +124,9 @@ class SharedExpertMLP(MLP):
         assert config.add_bias_linear == False, "bias is not supported in the shared experts, "
         "please set '--disable-bias-linear' instead."
 
+        if not config.activation_func_clamp_shared_expert:
+            config.activation_func_clamp_value = None
+
         config.ffn_hidden_size = config.moe_shared_expert_intermediate_size
         # TODO(Hepteract): pass pg_collection to MLP after refactoring MLP
         super().__init__(config=config, submodules=submodules, tp_group=pg_collection.tp, name=name)

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -223,6 +223,8 @@ class TransformerConfig(ModelParallelConfig):
     """Clamp the output of the linear_fc1 in the activation function. Only used when activation_func
     is quick_gelu or weighted SwiGLU (MoE only)."""
 
+    activation_func_clamp_shared_expert: bool = True
+
     num_moe_experts: Optional[int] = None
     """Number of experts to use for MoE layer. When set, it replaces MLP with MoE layer. Set to None
     for no MoE."""
@@ -867,6 +869,10 @@ class TransformerConfig(ModelParallelConfig):
     """TopK routing with dynamic per-expert bias in the aux-loss-free load balancing strategy.
     The routing decision is based on the sum of the routing scores and the expert bias.
     See https://arxiv.org/abs/2408.15664 for details."""
+
+    freeze_e_score_correction_bias: bool = False
+
+    moe_router_freeze_gate: bool = False
 
     moe_router_bias_update_rate: float = 1e-3
     """The expert bias is updated based on the number of assigned tokens to each expert

--- a/tests/unit_tests/distributed/test_finalize_model_grads.py
+++ b/tests/unit_tests/distributed/test_finalize_model_grads.py
@@ -36,8 +36,8 @@ class _RouterExpertBiasModel(torch.nn.Module):
         self.finish_grad_sync_calls += 1
 
 
-def _router_expert_bias_config():
-    return TransformerConfig(
+def _router_expert_bias_config(**overrides: object) -> TransformerConfig:
+    defaults: dict[str, object] = dict(
         num_layers=1,
         hidden_size=8,
         num_attention_heads=1,
@@ -47,6 +47,8 @@ def _router_expert_bias_config():
         moe_router_bias_update_rate=0.25,
         moe_router_load_balancing_type="none",
     )
+    defaults.update(overrides)
+    return TransformerConfig(**defaults)
 
 
 _NO_TP_DP_CP = object()
@@ -97,6 +99,20 @@ class TestFinalizeModelGradsMoEExpertBias:
         torch.testing.assert_close(
             model.router.local_tokens_per_expert, torch.zeros_like(local_tokens)
         )
+        assert model.finish_grad_sync_calls == 1
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_finalize_model_grads_preserves_frozen_router_expert_bias(self):
+        """Frozen expert correction bias must not be updated during gradient finalization."""
+        config = _router_expert_bias_config(freeze_e_score_correction_bias=True)
+        device = torch.device("cuda", torch.cuda.current_device())
+        model = _RouterExpertBiasModel(config, torch.tensor([0.0, 2.0], device=device))
+
+        finalize_model_grads(
+            [model], pg_collection=_router_bias_pg_collection(tp_dp_cp=dist.group.WORLD)
+        )
+
+        torch.testing.assert_close(model.router.expert_bias, torch.zeros(2, device=device))
         assert model.finish_grad_sync_calls == 1
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/tests/unit_tests/test_argument_utils.py
+++ b/tests/unit_tests/test_argument_utils.py
@@ -11,6 +11,7 @@ import pytest
 from megatron.core.distributed.distributed_data_parallel_config import DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig
 from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.training.argument_utils import (
     ArgumentGroupFactory,
     TypeInferenceError,
@@ -130,6 +131,24 @@ class TestArgumentGroupFactoryBasic:
         assert args.learning_rate == 0.001
         assert args.enabled == False
         assert args.disabled_feature == True
+
+    def test_dsv4_freeze_arguments_map_to_transformer_config(self):
+        """DSV4 freeze flags must remain accepted by the dataclass-generated CLI."""
+        parser = ArgumentParser()
+        factory = ArgumentGroupFactory(TransformerConfig)
+        factory.build_group(parser, title="Transformer configuration")
+
+        args = parser.parse_args(
+            [
+                "--no-activation-func-clamp-shared-expert",
+                "--moe-router-freeze-gate",
+                "--freeze-e-score-correction-bias",
+            ]
+        )
+
+        assert args.activation_func_clamp_shared_expert is False
+        assert args.moe_router_freeze_gate is True
+        assert args.freeze_e_score_correction_bias is True
 
     def test_argument_types(self):
         """Test that argument types are correctly inferred."""

--- a/tests/unit_tests/transformer/moe/test_routers.py
+++ b/tests/unit_tests/transformer/moe/test_routers.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 
 
+import dataclasses
 from typing import cast
 
 import pytest
@@ -65,6 +66,24 @@ class TestTop2Router:
 
         num_weights = sum([p.numel() for p in self.router.parameters()])
         assert num_weights == 12 * 4, num_weights
+
+    @pytest.mark.internal
+    def test_freeze_gate_disables_router_gradients(self):
+        """A frozen router gate must exclude its weight and bias from optimization."""
+        config = dataclasses.replace(
+            self.transformer_config, add_bias_linear=True, moe_router_freeze_gate=True
+        )
+        submodules = get_submodules(
+            get_gpt_layer_local_submodules(
+                num_experts=config.num_moe_experts, moe_grouped_gemm=False
+            ).mlp
+        )
+
+        router = cast(Router, MoELayer(config, submodules).router)
+
+        assert router.weight.requires_grad is False
+        assert router.bias is not None
+        assert router.bias.requires_grad is False
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/tests/unit_tests/transformer/moe/test_shared_experts.py
+++ b/tests/unit_tests/transformer/moe/test_shared_experts.py
@@ -337,6 +337,20 @@ class TestSharedExperts:
         moe_layer.cuda()
         return moe_layer
 
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_shared_expert_clamp_can_be_disabled(self):
+        """The DSV4 opt-out must leave routed experts clamped but shared experts unclamped."""
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, expert_model_parallel_size=1)
+
+        moe_layer = self.get_moe_layer(
+            activation_func_clamp_value=1.0, activation_func_clamp_shared_expert=False
+        )
+
+        assert moe_layer.config.activation_func_clamp_value == 1.0
+        assert moe_layer.shared_experts is not None
+        assert moe_layer.shared_experts.config.activation_func_clamp_value is None
+
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
 


### PR DESCRIPTION
## Why

Miles main currently fails both DeepSeek V4 H200 E2E variants before training starts:

- `test_deepseek_v4_flash_4layer_ci.py`
- `test_deepseek_v4_flash_4layer_megatron_impl_ci.py`

`train.py` rejects these arguments as unknown:

```text
--no-activation-func-clamp-shared-expert
--moe-router-freeze-gate
--freeze-e-score-correction-bias
```

The same failure is present in the Miles main nightly, so it is not introduced by a downstream Miles PR. Miles still passes these DeepSeek V4 options, while the current `miles-main` branch no longer exposes the corresponding `TransformerConfig` fields. Megatron builds these CLI options from dataclass fields, so removing the fields also removes the arguments from the parser.

These options are behavioral contracts, not parser-only compatibility flags. Accepting and ignoring them would let startup continue while silently changing the intended DeepSeek V4 training behavior.

## How this fixes the main failure

This PR restores the three `TransformerConfig` fields, which makes the dataclass-driven argument factory generate the expected CLI options again. It also reconnects each option to its runtime behavior:

- `--no-activation-func-clamp-shared-expert` keeps activation clamping for routed experts but clears the clamp on the deep-copied shared-expert config.
- `--moe-router-freeze-gate` marks the router weight and optional bias as not requiring gradients, excluding the gate from optimization.
- `--freeze-e-score-correction-bias` skips the expert-bias update during gradient finalization, preserving the frozen correction bias.

As a result, the Miles main DeepSeek V4 commands both parse successfully and retain the freeze/clamp semantics requested by their recipes.

## Tests

Added focused regressions for:

- CLI-to-`TransformerConfig` mapping for all three arguments
- frozen router gate parameters
- frozen expert correction bias during gradient finalization
- shared-expert activation-clamp opt-out

The eight changed files pass Black, isort, Ruff, and `git diff --check`. GPU-backed unit tests are left to draft PR CI because the local environments split torch and pytest across incompatible Python versions.