### PR TITLE
deepseek v4 support v2: miles + megatron backend

### DIFF
--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -540,7 +540,7 @@ def finalize_model_grads(
     if config.timers is not None:
         config.timers('embedding-grads-all-reduce').stop()
 
-    if config.moe_router_enable_expert_bias:
+    if config.moe_router_enable_expert_bias and not config.freeze_e_score_correction_bias:
         if pg_collection is None:
             tp_dp_cp_group = parallel_state.get_tensor_and_data_parallel_group(
                 with_context_parallel=True

--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -20,13 +20,7 @@ except:
 
 
 def _reduce(input_, group, fp32=False):
-    """All-reduce the input tensor across model parallel group.
-
-    Args:
-        input_: Input tensor.
-        group: Process group for all-reduce.
-        fp32: If True, cast to FP32 before all-reduce, then cast back.
-    """
+    """All-reduce across the model parallel group; `fp32` reduces in fp32 and casts back."""
     assert group is not None, "group should not be None"
 
     # Bypass the function if we are using only 1 GPU.
@@ -70,9 +64,7 @@ def _split_along_last_dim(input_, group):
 
 
 def split_along_nth_dim(input_, dim, group):
-    """Split the tensor along the specified dimension and keep the corresponding
-    slice. Pure function (no autograd). Used to scatter hash-routing input_ids
-    across the sequence dimension under sequence parallelism (miles dsv4)."""
+    """Keep this rank's slice of `input_` along `dim` (no autograd)."""
     assert group is not None, "group should not be None"
 
     world_size = group.size()
@@ -524,13 +516,7 @@ class _AllToAll(torch.autograd.Function):
 
 
 def copy_to_tensor_model_parallel_region(input_, group=None, all_reduce_grad_fp32=False):
-    """Wrapper for autograd function: forward: copy, backward allreduce
-
-    Args:
-        input_: Input tensor.
-        group: Process group for all-reduce. If None, uses default TP group.
-        all_reduce_grad_fp32: If True, cast gradients to FP32 before all-reduce, then cast back.
-    """
+    """Wrapper for autograd function: forward: copy, backward allreduce (fp32 if requested)"""
     group = get_tensor_model_parallel_group_if_none(group)
     return _CopyToModelParallelRegion.apply(input_, group, all_reduce_grad_fp32)
 

--- a/megatron/core/tensor_parallel/mappings.py
+++ b/megatron/core/tensor_parallel/mappings.py
@@ -19,8 +19,14 @@ except:
     dist_reduce_scatter_func = torch.distributed._reduce_scatter_base
 
 
-def _reduce(input_, group):
-    """All-reduce the input tensor across model parallel group."""
+def _reduce(input_, group, fp32=False):
+    """All-reduce the input tensor across model parallel group.
+
+    Args:
+        input_: Input tensor.
+        group: Process group for all-reduce.
+        fp32: If True, cast to FP32 before all-reduce, then cast back.
+    """
     assert group is not None, "group should not be None"
 
     # Bypass the function if we are using only 1 GPU.
@@ -28,11 +34,17 @@ def _reduce(input_, group):
         return input_
 
     # All-reduce.
-    # Note: If input_ is contiguous, it is mutated in-place.
-    # If not, a new contiguous tensor is created and returned;
-    # callers must use the returned value to ensure the reduced result is captured.
-    input_ = input_.contiguous()
-    torch.distributed.all_reduce(input_, group=group)
+    if fp32:
+        orig_dtype = input_.dtype
+        input_fp32 = input_.float().contiguous()
+        torch.distributed.all_reduce(input_fp32, group=group)
+        input_.copy_(input_fp32.to(orig_dtype))
+    else:
+        # Note: If input_ is contiguous, it is mutated in-place.
+        # If not, a new contiguous tensor is created and returned;
+        # callers must use the returned value to ensure the reduced result is captured.
+        input_ = input_.contiguous()
+        torch.distributed.all_reduce(input_, group=group)
 
     return input_
 
@@ -55,6 +67,27 @@ def _split_along_last_dim(input_, group):
     output = input_list[rank].contiguous()
 
     return output
+
+
+def split_along_nth_dim(input_, dim, group):
+    """Split the tensor along the specified dimension and keep the corresponding
+    slice. Pure function (no autograd). Used to scatter hash-routing input_ids
+    across the sequence dimension under sequence parallelism (miles dsv4)."""
+    assert group is not None, "group should not be None"
+
+    world_size = group.size()
+    if world_size == 1:
+        return input_
+
+    dim_size = input_.size(dim)
+    assert (
+        dim_size % world_size == 0
+    ), f"Dimension {dim} of the tensor (size {dim_size}) should be divisible by world size {world_size}"
+    local_dim_size = dim_size // world_size
+    rank = group.rank()
+    dim_offset = rank * local_dim_size
+
+    return input_.narrow(dim, dim_offset, local_dim_size).contiguous()
 
 
 def _split_along_first_dim(input_, group):
@@ -202,20 +235,21 @@ class _CopyToModelParallelRegion(torch.autograd.Function):
     """Pass the input to the model parallel region."""
 
     @staticmethod
-    def symbolic(graph, input_, group):
+    def symbolic(graph, input_, group, all_reduce_grad_fp32=False):
         """Symbolic function for tracing."""
         return input_
 
     @staticmethod
-    def forward(ctx, input_, group):
+    def forward(ctx, input_, group, all_reduce_grad_fp32=False):
         """Forward function."""
         ctx.group = group
+        ctx.all_reduce_grad_fp32 = all_reduce_grad_fp32
         return input_
 
     @staticmethod
     def backward(ctx, grad_output):
         """Backward function."""
-        return _reduce(grad_output, ctx.group), None
+        return _reduce(grad_output, ctx.group, fp32=ctx.all_reduce_grad_fp32), None, None
 
 
 class _ReduceFromModelParallelRegion(torch.autograd.Function):
@@ -489,10 +523,16 @@ class _AllToAll(torch.autograd.Function):
 # -----------------
 
 
-def copy_to_tensor_model_parallel_region(input_, group=None):
-    """Wrapper for autograd function: forward: copy, backward allreduce"""
+def copy_to_tensor_model_parallel_region(input_, group=None, all_reduce_grad_fp32=False):
+    """Wrapper for autograd function: forward: copy, backward allreduce
+
+    Args:
+        input_: Input tensor.
+        group: Process group for all-reduce. If None, uses default TP group.
+        all_reduce_grad_fp32: If True, cast gradients to FP32 before all-reduce, then cast back.
+    """
     group = get_tensor_model_parallel_group_if_none(group)
-    return _CopyToModelParallelRegion.apply(input_, group)
+    return _CopyToModelParallelRegion.apply(input_, group, all_reduce_grad_fp32)
 
 
 def reduce_from_tensor_model_parallel_region(input_, group=None):

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -1868,7 +1868,7 @@ class CompressedSparseAttention(MegatronModule):
                     q_indexer, k_indexer, weights_indexer = self.indexer.forward_before_topk(
                         x_det, qr_det, packed_seq_params
                     )
-                    indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0)
+                    indexer_loss_coeff = self.config.dsa_indexer_loss_coeff or 0.0
                     key_for_loss = compressed_kv.unsqueeze(2).expand(-1, -1, np, -1)
                     weights_for_unfused = weights_indexer.float() * self.indexer.softmax_scale
                     non_compressed_lse = _compute_unfused_csa_non_compressed_lse(
@@ -2212,7 +2212,7 @@ class CompressedSparseAttention(MegatronModule):
 
                     key_for_loss_thd = compressed_kv.unsqueeze(1).expand(-1, np_, -1)
                     weights_for_unfused = w_thd * self.indexer.softmax_scale
-                    indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0)
+                    indexer_loss_coeff = self.config.dsa_indexer_loss_coeff or 0.0
 
                     # Physical padded offsets define the packed address space;
                     # unpadded lengths identify the real rows within each segment.
@@ -2464,7 +2464,7 @@ class CompressedSparseAttention(MegatronModule):
         ``(total_q, 1, np * hn)``.
         """
         sparse_loss = getattr(self.config, "dsa_indexer_use_sparse_loss", True)
-        indexer_loss_coeff = getattr(self.config, 'dsa_indexer_loss_coeff', 0.0)
+        indexer_loss_coeff = self.config.dsa_indexer_loss_coeff or 0.0
 
         x_det = x.detach()
         qr_det = qr.detach()

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -14,6 +14,7 @@ from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.mappings import split_along_nth_dim
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.moe.moe_logging import get_moe_overload_factor_tracker
 from megatron.core.transformer.moe.moe_utils import (
@@ -460,12 +461,8 @@ class MoELayer(BaseMoELayer):
         This method uses the router to determine which experts to send each token to,
         producing routing probabilities and a mapping.
         """
-        # Hash routing reads input_ids per token; under sequence parallelism the hidden states
-        # (and thus the router scores) are scattered along the sequence dim, so input_ids must be
-        # scattered to match (miles dsv4). dim=1 is the sequence dim of input_ids ([bsz, seq]).
+        # sequence parallelism scatters hidden states along seq, so scatter input_ids to match
         if input_ids is not None and self.config.sequence_parallel:
-            from megatron.core.tensor_parallel.mappings import split_along_nth_dim
-
             input_ids = split_along_nth_dim(input_ids, dim=1, group=self.tp_group)
         probs, routing_map = apply_module(self.router)(
             hidden_states, padding_mask, input_ids, packed_seq_params

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -460,6 +460,13 @@ class MoELayer(BaseMoELayer):
         This method uses the router to determine which experts to send each token to,
         producing routing probabilities and a mapping.
         """
+        # Hash routing reads input_ids per token; under sequence parallelism the hidden states
+        # (and thus the router scores) are scattered along the sequence dim, so input_ids must be
+        # scattered to match (miles dsv4). dim=1 is the sequence dim of input_ids ([bsz, seq]).
+        if input_ids is not None and self.config.sequence_parallel:
+            from megatron.core.tensor_parallel.mappings import split_along_nth_dim
+
+            input_ids = split_along_nth_dim(input_ids, dim=1, group=self.tp_group)
         probs, routing_map = apply_module(self.router)(
             hidden_states, padding_mask, input_ids, packed_seq_params
         )

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -226,7 +226,10 @@ class TopKRouter(Router):
             tid2eid = torch.stack([(ids + k) % num_experts for k in range(self.topk)], dim=1).to(
                 torch.int32
             )
-            self.register_buffer('tid2eid', tid2eid)
+            # A parameter, not a buffer: miles' weight sync materializes full tensors from the
+            # parameter buffer, and a plain buffer gathers as zeros — which would then overwrite
+            # the inference engine's own table.
+            self.tid2eid = torch.nn.Parameter(tid2eid, requires_grad=False)
         else:
             self.tid2eid = None
 

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -88,6 +88,11 @@ class Router(ABC, MegatronModule):
         self.calculate_per_token_loss = self.config.calculate_per_token_loss
         self.reset_parameters()
 
+        if self.config.moe_router_freeze_gate:
+            self.weight.requires_grad = False
+            if self.bias is not None:
+                self.bias.requires_grad = False
+
     def reset_parameters(self):
         """Reset the router parameters."""
         if self.config.perform_initialization:
@@ -114,6 +119,11 @@ class Router(ABC, MegatronModule):
             self.weight.data = self.weight.data.to(device=torch.cuda.current_device())
         if self.bias is not None and self.bias.device.type == 'cpu':
             self.bias.data = self.bias.data.to(device=torch.cuda.current_device())
+
+        if self.config.moe_router_freeze_gate:
+            assert not self.weight.requires_grad
+            if self.bias is not None:
+                assert not self.bias.requires_grad
 
         # Convert to specified datatype for routing computation if enabled
         router_dtype = input.dtype
@@ -244,6 +254,9 @@ class TopKRouter(Router):
         else:
             self.local_tokens_per_expert = None
             self.expert_bias = None
+
+        if self.config.freeze_e_score_correction_bias and self.enable_expert_bias:
+            self._frozen_expert_bias_snapshot = None
 
         # Initialize global tokens per expert for global aux loss
         if self.get_aux_loss_coeff("global_aux_loss") > 0:
@@ -927,6 +940,14 @@ class TopKRouter(Router):
                                                 Defaults to None.
         """
         self._maintain_float32_expert_bias()
+
+        if self.config.freeze_e_score_correction_bias and self.enable_expert_bias:
+            if self._frozen_expert_bias_snapshot is None:
+                self._frozen_expert_bias_snapshot = self.expert_bias.clone()
+            else:
+                assert torch.equal(self.expert_bias, self._frozen_expert_bias_snapshot), (
+                    "expert_bias was modified but freeze_e_score_correction_bias is enabled!"
+                )
 
         # Apply input jitter
         input = self.apply_input_jitter(input)

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -120,11 +120,6 @@ class Router(ABC, MegatronModule):
         if self.bias is not None and self.bias.device.type == 'cpu':
             self.bias.data = self.bias.data.to(device=torch.cuda.current_device())
 
-        if self.config.moe_router_freeze_gate:
-            assert not self.weight.requires_grad
-            if self.bias is not None:
-                assert not self.bias.requires_grad
-
         # Convert to specified datatype for routing computation if enabled
         router_dtype = input.dtype
         if self.config.moe_router_dtype == 'fp32':
@@ -255,9 +250,6 @@ class TopKRouter(Router):
         else:
             self.local_tokens_per_expert = None
             self.expert_bias = None
-
-        if self.config.freeze_e_score_correction_bias and self.enable_expert_bias:
-            self._frozen_expert_bias_snapshot = None
 
         # Initialize global tokens per expert for global aux loss
         if self.get_aux_loss_coeff("global_aux_loss") > 0:
@@ -943,14 +935,6 @@ class TopKRouter(Router):
                                                 Defaults to None.
         """
         self._maintain_float32_expert_bias()
-
-        if self.config.freeze_e_score_correction_bias and self.enable_expert_bias:
-            if self._frozen_expert_bias_snapshot is None:
-                self._frozen_expert_bias_snapshot = self.expert_bias.clone()
-            else:
-                assert torch.equal(self.expert_bias, self._frozen_expert_bias_snapshot), (
-                    "expert_bias was modified but freeze_e_score_correction_bias is enabled!"
-                )
 
         # Apply input jitter
         input = self.apply_input_jitter(input)

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -290,7 +290,10 @@ class TopKRouter(Router):
         # training. No-op (early return) unless miles enables the manager.
         from miles.utils.replay_base import routing_replay_manager
 
-        routing_replay_manager.register_to_module(self, "routing_replay")
+        # Rollout routing replay only records main-decoder MoE layers; an MTP slot would
+        # register a stream nothing ever fills and then pop from it during replay.
+        if not self.is_mtp_layer:
+            routing_replay_manager.register_to_module(self, "routing_replay")
 
     def _maintain_float32_expert_bias(self):
         """

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -226,9 +226,7 @@ class TopKRouter(Router):
             tid2eid = torch.stack([(ids + k) % num_experts for k in range(self.topk)], dim=1).to(
                 torch.int32
             )
-            # A parameter, not a buffer: miles' weight sync materializes full tensors from the
-            # parameter buffer, and a plain buffer gathers as zeros — which would then overwrite
-            # the inference engine's own table.
+            # parameter, not buffer: the sync gathers buffers as zeros, clobbering the engine table
             self.tid2eid = torch.nn.Parameter(tid2eid, requires_grad=False)
         else:
             self.tid2eid = None
@@ -290,8 +288,7 @@ class TopKRouter(Router):
         # training. No-op (early return) unless miles enables the manager.
         from miles.utils.replay_base import routing_replay_manager
 
-        # Rollout routing replay only records main-decoder MoE layers; an MTP slot would
-        # register a stream nothing ever fills and then pop from it during replay.
+        # replay only records main-decoder MoE layers; an MTP router would pop from an empty stream
         if not self.is_mtp_layer:
             routing_replay_manager.register_to_module(self, "routing_replay")
 

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -124,6 +124,9 @@ class SharedExpertMLP(MLP):
         assert config.add_bias_linear == False, "bias is not supported in the shared experts, "
         "please set '--disable-bias-linear' instead."
 
+        if not config.activation_func_clamp_shared_expert:
+            config.activation_func_clamp_value = None
+
         config.ffn_hidden_size = config.moe_shared_expert_intermediate_size
         # TODO(Hepteract): pass pg_collection to MLP after refactoring MLP
         super().__init__(config=config, submodules=submodules, tp_group=pg_collection.tp, name=name)

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2913,14 +2913,22 @@ class TransformerConfig(ModelParallelConfig):
                 self.actual_vocab_size is not None
             ), "actual_vocab_size must be set when moe_n_hash_layers > 0."
             if self.pipeline_model_parallel_size > 1 and not self.is_hybrid_model:
-                assert self.pipeline_model_parallel_layout is not None, (
-                    "pipeline_model_parallel_layout must be set when using hash MoE "
-                    "layers with pipeline parallelism (PP > 1)."
-                )
-                # The embedding is always in layout[0][0] (PP rank 0, VPP rank 0).
-                # All hash MoE layers must be in the same virtual pipeline stage.
-                embedding_stage = self.pipeline_model_parallel_layout.layout[0][0]
-                n_decoders_with_embedding = embedding_stage.count(LayerType.decoder)
+                # Hash routing reads input_ids, which only reaches the stage that owns the
+                # embedding, so every hash layer has to be built there. An explicit layout is
+                # one way to spell that stage's size; uneven first/last stages and the even
+                # split are others, so ask the layer distribution rather than the layout.
+                if self.pipeline_model_parallel_layout is not None:
+                    # The embedding is always in layout[0][0] (PP rank 0, VPP rank 0).
+                    embedding_stage = self.pipeline_model_parallel_layout.layout[0][0]
+                    n_decoders_with_embedding = embedding_stage.count(LayerType.decoder)
+                else:
+                    from megatron.core.transformer.transformer_block import (
+                        get_num_layers_to_build,
+                    )
+
+                    n_decoders_with_embedding = get_num_layers_to_build(
+                        self, vp_stage=0, pp_rank=0
+                    )
                 assert self.moe_n_hash_layers <= n_decoders_with_embedding, (
                     f"Currently, All hash MoE layers must be in the same virtual pipeline stage "
                     f"as the embedding. The embedding stage has "

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -307,10 +307,15 @@ class TransformerConfig(ModelParallelConfig):
     ####################
     # attention variant
     ####################
-    experimental_attention_variant: Optional[Literal['gated_delta_net', 'dsa', 'dsv4_hybrid']] = (
-        None
-    )
-    """Type of attention variant to use. Currently support gated_delta_net, dsa, and dsv4_hybrid."""
+    experimental_attention_variant: Optional[
+        Literal['gated_delta_net', 'dsa', 'dsv4_hybrid', 'dsv4']
+    ] = None
+    """Type of attention variant to use. Currently support gated_delta_net, dsa, dsv4_hybrid, and
+    dsv4 (miles' custom DeepSeek-V4 sparse-attention path; see bump_docs/02-deepseek-v4.md)."""
+
+
+
+
 
     cp_partition_mode: Literal["zigzag", "contiguous"] = "zigzag"
     """How THD sequence rows are partitioned across context-parallel ranks.
@@ -873,6 +878,12 @@ class TransformerConfig(ModelParallelConfig):
     in a global batch, where the bias is increased for the experts with less assigned tokens
     and decreased for the experts with more assigned tokens.
     The default value 1e-3 is same as that used in DeepSeekV3."""
+
+    freeze_e_score_correction_bias: bool = False
+    """Freeze expert score correction bias during training (DSv4 RL)."""
+
+    moe_router_freeze_gate: bool = False
+    """Freeze MoE router gate weights during training (DSv4 RL)."""
 
     moe_router_force_load_balancing: bool = False
     """[Experimental] Force load balancing with random logits for MoE router, supports naive topk 
@@ -1754,6 +1765,10 @@ class TransformerConfig(ModelParallelConfig):
                     "DSAttention context parallelism currently supports "
                     "cp_comm_type=allgather only."
                 )
+        elif self.experimental_attention_variant == "dsv4":
+            # miles' DeepSeek-V4 attention (BSHD, sparse CP, tilelang kernels). Hyper-connections
+            # come from the native module; unlike dsv4_hybrid this path allows TP>1 and CP>1.
+            assert self.multi_latent_attention, "dsv4 requires multi_latent_attention."
         elif self.experimental_attention_variant == "dsv4_hybrid":
             assert self.multi_latent_attention, "DSv4 Hybrid requires multi_latent_attention."
             assert self.csa_compress_ratios is not None, "csa_compress_ratios must be set"

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -223,6 +223,10 @@ class TransformerConfig(ModelParallelConfig):
     """Clamp the output of the linear_fc1 in the activation function. Only used when activation_func
     is quick_gelu or weighted SwiGLU (MoE only)."""
 
+    activation_func_clamp_shared_expert: bool = True
+    """If False, skip activation_func_clamp_value inside SharedExpertMLP so only routed MoE
+    experts get the clamp."""
+
     num_moe_experts: Optional[int] = None
     """Number of experts to use for MoE layer. When set, it replaces MLP with MoE layer. Set to None
     for no MoE."""

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -315,11 +315,7 @@ class TransformerConfig(ModelParallelConfig):
         Literal['gated_delta_net', 'dsa', 'dsv4_hybrid', 'dsv4']
     ] = None
     """Type of attention variant to use. Currently support gated_delta_net, dsa, dsv4_hybrid, and
-    dsv4 (miles' custom DeepSeek-V4 sparse-attention path; see bump_docs/02-deepseek-v4.md)."""
-
-
-
-
+    dsv4 (miles' DeepSeek-V4 sparse-attention path)."""
 
     cp_partition_mode: Literal["zigzag", "contiguous"] = "zigzag"
     """How THD sequence rows are partitioned across context-parallel ranks.
@@ -1770,8 +1766,6 @@ class TransformerConfig(ModelParallelConfig):
                     "cp_comm_type=allgather only."
                 )
         elif self.experimental_attention_variant == "dsv4":
-            # miles' DeepSeek-V4 attention (BSHD, sparse CP, tilelang kernels). Hyper-connections
-            # come from the native module; unlike dsv4_hybrid this path allows TP>1 and CP>1.
             assert self.multi_latent_attention, "dsv4 requires multi_latent_attention."
         elif self.experimental_attention_variant == "dsv4_hybrid":
             assert self.multi_latent_attention, "DSv4 Hybrid requires multi_latent_attention."
@@ -2913,10 +2907,8 @@ class TransformerConfig(ModelParallelConfig):
                 self.actual_vocab_size is not None
             ), "actual_vocab_size must be set when moe_n_hash_layers > 0."
             if self.pipeline_model_parallel_size > 1 and not self.is_hybrid_model:
-                # Hash routing reads input_ids, which only reaches the stage that owns the
-                # embedding, so every hash layer has to be built there. An explicit layout is
-                # one way to spell that stage's size; uneven first/last stages and the even
-                # split are others, so ask the layer distribution rather than the layout.
+                # hash layers read input_ids, which only the embedding stage has, so all live there;
+                # the stage size may come from a layout, uneven first/last, or the even split
                 if self.pipeline_model_parallel_layout is not None:
                     # The embedding is always in layout[0][0] (PP rank 0, VPP rank 0).
                     embedding_stage = self.pipeline_model_parallel_layout.layout[0][0]

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2914,13 +2914,9 @@ class TransformerConfig(ModelParallelConfig):
                     embedding_stage = self.pipeline_model_parallel_layout.layout[0][0]
                     n_decoders_with_embedding = embedding_stage.count(LayerType.decoder)
                 else:
-                    from megatron.core.transformer.transformer_block import (
-                        get_num_layers_to_build,
-                    )
+                    from megatron.core.transformer.transformer_block import get_num_layers_to_build
 
-                    n_decoders_with_embedding = get_num_layers_to_build(
-                        self, vp_stage=0, pp_rank=0
-                    )
+                    n_decoders_with_embedding = get_num_layers_to_build(self, vp_stage=0, pp_rank=0)
                 assert self.moe_n_hash_layers <= n_decoders_with_embedding, (
                     f"Currently, All hash MoE layers must be in the same virtual pipeline stage "
                     f"as the embedding. The embedding stage has "

--- a/megatron/training/argument_utils.py
+++ b/megatron/training/argument_utils.py
@@ -421,7 +421,12 @@ def core_transformer_config_from_args(args, config_class=None):
     kw_args['pipeline_dtype'] = args.params_dtype
     kw_args['batch_p2p_comm'] = not args.overlap_p2p_comm
     kw_args['num_moe_experts'] = args.num_experts
-    kw_args['actual_vocab_size'] = args.padded_vocab_size
+    # Hash-MoE routing (consumes actual_vocab_size for the tid2eid table) needs the TRUE unpadded
+    # vocab so the table size is TP-independent and matches the checkpoint. Fall back to padded
+    # when --vocab-size is not given. (actual_vocab_size is only read by hash routing.)
+    kw_args['actual_vocab_size'] = (
+        args.vocab_size if getattr(args, 'vocab_size', None) else args.padded_vocab_size
+    )
     kw_args['rotary_interleaved'] = args.rotary_interleaved
     kw_args['num_layers_in_first_pipeline_stage'] = args.decoder_first_pipeline_num_layers
     kw_args['num_layers_in_last_pipeline_stage'] = args.decoder_last_pipeline_num_layers

--- a/megatron/training/argument_utils.py
+++ b/megatron/training/argument_utils.py
@@ -421,9 +421,7 @@ def core_transformer_config_from_args(args, config_class=None):
     kw_args['pipeline_dtype'] = args.params_dtype
     kw_args['batch_p2p_comm'] = not args.overlap_p2p_comm
     kw_args['num_moe_experts'] = args.num_experts
-    # Hash-MoE routing (consumes actual_vocab_size for the tid2eid table) needs the TRUE unpadded
-    # vocab so the table size is TP-independent and matches the checkpoint. Fall back to padded
-    # when --vocab-size is not given. (actual_vocab_size is only read by hash routing.)
+    # tid2eid is sized from the unpadded vocab (TP-independent); only miles passes --vocab-size
     kw_args['actual_vocab_size'] = (
         args.vocab_size if getattr(args, 'vocab_size', None) else args.padded_vocab_size
     )

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2237,9 +2237,7 @@ def core_transformer_config_from_args(args, config_class=None):
     kw_args['pipeline_dtype'] = args.params_dtype
     kw_args['batch_p2p_comm'] = not args.overlap_p2p_comm
     kw_args['num_moe_experts'] = args.num_experts
-    # Hash-MoE routing (consumes actual_vocab_size for the tid2eid table) needs the TRUE unpadded
-    # vocab so the table size is TP-independent and matches the checkpoint. Fall back to padded
-    # when --vocab-size is not given. (actual_vocab_size is only read by hash routing.)
+    # tid2eid is sized from the unpadded vocab (TP-independent); only miles passes --vocab-size
     kw_args['actual_vocab_size'] = (
         args.vocab_size if getattr(args, 'vocab_size', None) else args.padded_vocab_size
     )

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2237,7 +2237,12 @@ def core_transformer_config_from_args(args, config_class=None):
     kw_args['pipeline_dtype'] = args.params_dtype
     kw_args['batch_p2p_comm'] = not args.overlap_p2p_comm
     kw_args['num_moe_experts'] = args.num_experts
-    kw_args['actual_vocab_size'] = args.padded_vocab_size
+    # Hash-MoE routing (consumes actual_vocab_size for the tid2eid table) needs the TRUE unpadded
+    # vocab so the table size is TP-independent and matches the checkpoint. Fall back to padded
+    # when --vocab-size is not given. (actual_vocab_size is only read by hash routing.)
+    kw_args['actual_vocab_size'] = (
+        args.vocab_size if getattr(args, 'vocab_size', None) else args.padded_vocab_size
+    )
     kw_args['rotary_interleaved'] = args.rotary_interleaved
     kw_args['num_layers_in_first_pipeline_stage'] = args.decoder_first_pipeline_num_layers
     kw_args['num_layers_in_last_pipeline_stage'] = args.decoder_last_pipeline_num_layers

--- a/tests/unit_tests/transformer/moe/test_routers.py
+++ b/tests/unit_tests/transformer/moe/test_routers.py
@@ -761,3 +761,41 @@ class TestHashRouting:
         output.sum().backward()
         assert hidden_states.grad is not None
         assert not torch.isnan(hidden_states.grad).any()
+
+
+class TestHashRoutingPipelineValidation:
+    """Hash layers read input_ids, so they must all land on the embedding's stage.
+
+    The stage's size can be spelled three ways; the check has to read all of them.
+    """
+
+    # 8 layers over PP4, each spelling giving the embedding stage 2 decoder layers.
+    SPELLINGS = [
+        pytest.param(dict(pipeline_model_parallel_layout="Ett|tt|tt|ttL"), id="layout"),
+        pytest.param(
+            dict(num_layers_in_first_pipeline_stage=2, num_layers_in_last_pipeline_stage=2),
+            id="uneven_first_last",
+        ),
+        pytest.param({}, id="even_split"),
+    ]
+
+    @staticmethod
+    def _config(n_hash_layers, **overrides):
+        return _hash_routing_config(
+            num_layers=8,
+            pipeline_model_parallel_size=4,
+            pipeline_dtype=torch.bfloat16,
+            moe_n_hash_layers=n_hash_layers,
+            **overrides,
+        )
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize("spelling", SPELLINGS)
+    def test_hash_layers_fitting_the_embedding_stage_are_accepted(self, spelling):
+        self._config(2, **spelling)
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize("spelling", SPELLINGS)
+    def test_hash_layers_spilling_past_the_embedding_stage_are_rejected(self, spelling):
+        with pytest.raises(AssertionError, match="same virtual pipeline stage"):
+            self._config(3, **spelling)


### PR DESCRIPTION
## Why

radixark/miles#2706 (DeepSeek-V4 support-v2, merged 2026-08-31) re-enabled the two DeepSeek-V4 H200 E2E tests and ran its CI against this branch via `ci-megatron-pr: dsv4-dual-backend`. The branch was never merged, so every other miles PR and the main nightly resolve Megatron to `miles-main` and fail both tests before training starts:

```text
train.py: error: unrecognized arguments: --no-activation-func-clamp-shared-expert --moe-router-freeze-gate --freeze-e-score-correction-bias
```

Megatron generates these CLI options from `TransformerConfig` dataclass fields; the fields only exist on this branch (`transformer_config.py`: `activation_func_clamp_shared_expert`, `freeze_e_score_correction_bias`, `moe_router_freeze_gate`). Because the E2E partitions stop at the first failure, the tests queued behind DeepSeek-V4 (inkling LoRA, GLM 5.2, Kimi) are also lost.

Restoring only the three fields (#92, closed) is not enough: miles#2706 also depends on the attention variant and the routing/weight-sync fixes below. This branch is the exact combination miles#2706 validated.

## What lands (7 commits, `miles-main-20260819` + dsv4)

- bf12f862f dsv4: add the miles DeepSeek-V4 attention variant
- 73ffc6be5 dsv4: fix hash-routing under tensor parallelism, add MoE freeze knobs
- 58fe41c07 dsv4: keep the shared-expert opt-out for the SwiGLU clamp
- be964e9e9 dsv4: keep tid2eid a parameter so the weight sync ships it
- cc331b573 dsv4: keep rollout routing replay off MTP routers
- 6184c094a dsv4: read the DSA indexer loss coeff the way the rest of the file does
- e4f952a2b dsv4: read the embedding stage's size from the layer distribution

`miles-main` is one commit ahead of this branch (c160f0717, optimizer files only); the two sides touch disjoint files, so the merge is conflict-free.

## Validation

miles run [33121695746](https://github.com/radixark/miles/actions/runs/33121695746) (miles#2706 at 8a19557d1, Megatron = this branch at its current head e4f952a2b) passed `test_deepseek_v4_flash_4layer_ci.py` (1307s) and `test_deepseek_v4_flash_4layer_megatron_impl_ci.py` (1088s) together with the rest of the model-scripts suite (inkling, inkling LoRA, Kimi K2.5, GLM 5.2, gpt-oss LoRA). The branch head has not changed since 2026-08-25.

miles CI checks out `miles-main` at job start, so this takes effect on the next PR run without an image rebuild.

## Cleanup on top of the branch

- 3f6c6b1 dsv4: trim the comments and docstrings to the constraint each line needs
- 81c9d04 dsv4: drop the per-forward freeze asserts (`requires_grad` is cleared in `__init__` and `finalize_model_grads` owns the bias freeze; the `torch.equal` snapshot check cost a device sync per MoE layer per forward)
- 3fd2ef9 format: black on the dsv4 hunks

No behavior change other than the removed asserts.