### PR TITLE
Add the Kimi K3 backend primitives

### DIFF
--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -396,8 +396,20 @@ def _allreduce_non_tensor_model_parallel_grads(
         ddp_config = model_chunk.ddp_config
         for name, param in get_attr_wrapped_model(model_chunk, 'named_parameters')():
             if param.requires_grad:
+                # TP-replicated params whose grad is a partial sum over the TP shards (K3 LoRA)
+                if getattr(param, "sum_gradients_across_tp_domain", False):
+                    grad_attr = _get_main_grad_attr(param)
+                    grad = getattr(param, grad_attr)
+                    if grad is None:
+                        continue
+                    params_sum.append(param)
+                    if ddp_config.use_megatron_fsdp:
+                        grads_sum.append(grad._local_tensor.data)
+                    else:
+                        grad = _unshard_if_dtensor(grad)
+                        grads_sum.append(grad.data)
                 # Check if this param needs average reduction (average_gradients_across_tp_domain)
-                if getattr(param, "average_gradients_across_tp_domain", False):
+                elif getattr(param, "average_gradients_across_tp_domain", False):
                     grad_attr = _get_main_grad_attr(param)
                     grad = getattr(param, grad_attr)
                     if grad is None:

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -314,7 +314,9 @@ class MLP(MegatronModule):
         else:
             if bias_parallel is not None:
                 intermediate_parallel = intermediate_parallel + bias_parallel
-            if self.config.gated_linear_unit:
+            if self.config.gated_activation_func is not None:
+                intermediate_parallel = self.config.gated_activation_func(intermediate_parallel)
+            elif self.config.gated_linear_unit:
 
                 def glu(x):
                     x_glu, x_linear = torch.chunk(x, 2, dim=-1)

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -887,7 +887,13 @@ class TEGroupedMLP(MegatronModule):
                     intermediate_parallel, permuted_probs
                 )
             else:
-                if self.config.gated_linear_unit:
+                if self.config.gated_activation_func is not None:
+                    if with_glu_interleaving:
+                        intermediate_parallel = self._remove_glu_interleaving(
+                            intermediate_parallel, self.config.moe_mlp_glu_interleave_size
+                        )
+                    intermediate_parallel = self.config.gated_activation_func(intermediate_parallel)
+                elif self.config.gated_linear_unit:
 
                     def glu(x):
                         if with_glu_interleaving:

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -64,9 +64,9 @@ except ImportError:
     HAVE_TRITON = False
 
 if HAVE_TE:
-    from megatron.core.extensions.transformer_engine import TELinear, te_checkpoint
+    from megatron.core.extensions.transformer_engine import TELinear, TENorm, te_checkpoint
 else:
-    TELinear, te_checkpoint = None, None
+    TELinear, TENorm, te_checkpoint = None, None, None
 
 
 class ExpertsInterface(Protocol):
@@ -303,6 +303,12 @@ class MoELayer(BaseMoELayer):
                 is_expert=False,
                 name=(name + ".fc2_latent_proj") if name is not None else None,
             )
+            if self.config.moe_latent_use_norm:
+                self.routed_expert_norm = TENorm(
+                    config=self.config,
+                    hidden_size=self.config.moe_latent_size,
+                    eps=self.config.layernorm_epsilon,
+                )
 
         # Initialize token dispatcher
         if config.moe_token_dispatcher_type == "allgather":
@@ -647,6 +653,8 @@ class MoELayer(BaseMoELayer):
 
         output = self.token_dispatcher.combine_postprocess(output)
         if self.config.moe_latent_size:
+            if self.config.moe_latent_use_norm:
+                output = self.routed_expert_norm(output)
             output, _ = self.fc2_latent_proj(output)
 
         if shared_expert_output is not None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -211,6 +211,10 @@ class TransformerConfig(ModelParallelConfig):
     activation_func: Callable[[torch.Tensor], torch.Tensor] = F.gelu
     """Activation function to use for the non-linearity in the MLP."""
 
+    gated_activation_func: Optional[Callable[[torch.Tensor], torch.Tensor]] = None
+    """Activation that consumes the packed [gate | linear] GLU input itself (Kimi K3's situ);
+    None keeps the activation_func(gate) * linear form."""
+
     activation_func_fp8_input_store: bool = False
     """Store the input of MLP activation function in FP8 for backprop to save memory.
     The stored input is casted back to the original precision before backprop compuatation."""
@@ -1026,6 +1030,9 @@ class TransformerConfig(ModelParallelConfig):
 
     moe_latent_size: Optional[int] = None
     """Latent projection dimension for MoE. If None, MoE latent projections are not used."""
+
+    moe_latent_use_norm: bool = False
+    """RMSNorm the combined routed output in latent space before fc2_latent_proj (Kimi K3)."""
 
     moe_flex_dispatcher_num_sms: Optional[int] = None
     """Number of SMs for the flex token dispatcher's dispatch/combine communication, for all

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2753,6 +2753,7 @@ def _add_network_size_args(parser):
         "output_layer_init_method",
         "embedding_init_method",
         "activation_func",
+        "gated_activation_func",
         "experimental_attention_variant_loss_scale_func",
         # types affect docstring
         "pipeline_model_parallel_layout",


### PR DESCRIPTION
Three hooks the Kimi K3 plugin in miles (radixark/miles#1825) relies on, ported from the K3 review fork (yueming-yuan/k3-megatron-review@ebe3b9d7f) onto `miles-main`. They were never opened against this repo; the K3 image carried the fork instead.

- `TransformerConfig.gated_activation_func`: an activation that consumes the packed `[gate | linear]` GLU input itself (K3's situ). `MLP` and `TEGroupedMLP` call it in place of `activation_func(gate) * linear` when set; `None` keeps today's behavior.
- `TransformerConfig.moe_latent_use_norm`: RMSNorm the combined routed output in latent space before `fc2_latent_proj` (K3's `routed_expert_norm`, a real checkpoint tensor).
- `Parameter.sum_gradients_across_tp_domain`: sum, not average, TP-replicated partial gradients in `finalize_model_grads`, for K3's expert-shared LoRA factors whose gradient is a partial sum over the TP shards.

Without the norm hook a K3 checkpoint loads with the latent norm silently dropped; `--check-weight-update-equal` on the 4-layer K3 run caught it as `routed_expert_norm.weight` never reaching the engine.

## Validation

- 4-layer Kimi K3 LoRA RL smoke run (colocated, 8xH200, radixark/miles#1825 + sgl-project/sglang `yueming/k3-lora-on-sglang-miles`) with `--check-weight-update-equal`: base weights compare equal after the sync, two rollouts train.
- Not executed: a TP>1 run exercising `sum_gradients_across_tp_domain` (the smoke run is TP=1); no unit test — the fork's only test covered an unrelated SGD change that is already on `miles-main`.
